### PR TITLE
chore: bump 'trim' from 0.0.1 to 0.0.3

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -43,6 +43,9 @@
     "prettier": "^2.7.1",
     "stylelint": "^14.9.1"
   },
+  "resolutions": {
+    "trim": "0.0.3"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8984,10 +8984,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==
+trim@0.0.1, trim@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Upgraded the trim version to 0.0.3, based on grype finding:

> ```
> NAME       INSTALLED  FIXED-IN  TYPE  VULNERABILITY        SEVERITY
> trim       0.0.1      0.0.3     npm   GHSA-w5p7-h5w8-2hfq  High 
> ```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)
