### PR TITLE
chore: change pythonExec to python3

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -185,16 +185,16 @@ const exampleApp = new awscdk.AwsCdkPythonApp({
 
   parent: rootProject,
   outdir: 'example',
- 
+
   cdkVersion: CDK_VERSION,
   constructsVersion: CDK_CONSTRUCTS_VERSION,
   cdkVersionPinning: true,
-  
+
   pytest: true,
   devDeps: [
     "pytest",
   ],
-
+  pythonExec: 'python3',
   venvOptions: {
     envdir: '.venv'
   },


### PR DESCRIPTION
**Issue #, if available:**

```
Error: Command failed: python -m venv .venv
/bin/sh: line 1: python: command not found
```

## Description of changes:

changing `pythonExec` to `python3` as python is python 2 (deprecated)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

if people are still using python2...

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
