### PR TITLE
chore: use jsii container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           name: build-artifact
           path: dist
+    container:
+      image: jsii/superchain:1-buster-slim-node16
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -105,6 +107,8 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    container:
+      image: jsii/superchain:1-buster-slim-node16
   release_pypi:
     name: Publish to PyPI
     needs: release
@@ -140,3 +144,5 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: npx -p publib@latest publib-pypi
+    container:
+      image: jsii/superchain:1-buster-slim-node16


### PR DESCRIPTION
**Issue #, if available:**

use the following to get jsii available

```
container:
      image: jsii/superchain:1-buster-slim-node16
```

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
