### PR TITLE
ci: Use examples artifact for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,17 @@ jobs:
         with:
           name: build-artifact
           path: framework/dist
+      - name: Backup examples permissions
+        working-directory: examples
+        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
+        run: getfacl -R . > permissions-backup.acl
+        continue-on-error: true
+      - name: Upload examples artifact
+        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: examples-artifact
+          path: examples
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -57,9 +68,18 @@ jobs:
         with:
           name: build-artifact
           path: framework/dist
+      - name: Download examples artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: examples-artifact
+          path: examples          
       - name: Restore build artifact permissions
         working-directory: framework
         run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Restore examples artifact permissions
+        working-directory: examples
+        run: setfacl --restore=permissions-backup.acl
         continue-on-error: true
       - name: Prepare Repository
         working-directory: framework


### PR DESCRIPTION
## Description of changes:

This PR introduces the usage of an example artifact created during the release process. With that, the workflow can process and upload this artifact as a release asset.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
