### PR TITLE
feat: DataVpc construct

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -3357,6 +3357,209 @@ public readonly DSF_TRACKING_CODE: string;
 
 ---
 
+### DataVpc <a name="DataVpc" id="aws-dsf.utils.DataVpc"></a>
+
+#### Initializers <a name="Initializers" id="aws-dsf.utils.DataVpc.Initializer"></a>
+
+```typescript
+import { utils } from 'aws-dsf'
+
+new utils.DataVpc(scope: Construct, id: string, props: DataVpcProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-dsf.utils.DataVpc.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#aws-dsf.utils.DataVpc.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#aws-dsf.utils.DataVpc.Initializer.parameter.props">props</a></code> | <code>aws-dsf.utils.DataVpcProps</code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="aws-dsf.utils.DataVpc.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="aws-dsf.utils.DataVpc.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="aws-dsf.utils.DataVpc.Initializer.parameter.props"></a>
+
+- *Type:* aws-dsf.utils.DataVpcProps
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#aws-dsf.utils.DataVpc.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#aws-dsf.utils.DataVpc.tagVpc">tagVpc</a></code> | Tag the VPC and the subnets. |
+
+---
+
+##### `toString` <a name="toString" id="aws-dsf.utils.DataVpc.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `tagVpc` <a name="tagVpc" id="aws-dsf.utils.DataVpc.tagVpc"></a>
+
+```typescript
+public tagVpc(key: string, value: string): void
+```
+
+Tag the VPC and the subnets.
+
+###### `key`<sup>Required</sup> <a name="key" id="aws-dsf.utils.DataVpc.tagVpc.parameter.key"></a>
+
+- *Type:* string
+
+the tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="aws-dsf.utils.DataVpc.tagVpc.parameter.value"></a>
+
+- *Type:* string
+
+the tag value.
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#aws-dsf.utils.DataVpc.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="aws-dsf.utils.DataVpc.isConstruct"></a>
+
+```typescript
+import { utils } from 'aws-dsf'
+
+utils.DataVpc.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="aws-dsf.utils.DataVpc.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-dsf.utils.DataVpc.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#aws-dsf.utils.DataVpc.property.flowLogGroup">flowLogGroup</a></code> | <code>aws-cdk-lib.aws_logs.ILogGroup</code> | The CloudWatch Log Group created for the VPC flow logs. |
+| <code><a href="#aws-dsf.utils.DataVpc.property.flowLogKey">flowLogKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS Key used to encrypt VPC flow logs. |
+| <code><a href="#aws-dsf.utils.DataVpc.property.flowLogRole">flowLogRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM role used to publish VPC Flow Logs. |
+| <code><a href="#aws-dsf.utils.DataVpc.property.s3VpcEndpoint">s3VpcEndpoint</a></code> | <code>aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint</code> | The S3 VPC endpoint. |
+| <code><a href="#aws-dsf.utils.DataVpc.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The amazon VPC created. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="aws-dsf.utils.DataVpc.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `flowLogGroup`<sup>Required</sup> <a name="flowLogGroup" id="aws-dsf.utils.DataVpc.property.flowLogGroup"></a>
+
+```typescript
+public readonly flowLogGroup: ILogGroup;
+```
+
+- *Type:* aws-cdk-lib.aws_logs.ILogGroup
+
+The CloudWatch Log Group created for the VPC flow logs.
+
+---
+
+##### `flowLogKey`<sup>Required</sup> <a name="flowLogKey" id="aws-dsf.utils.DataVpc.property.flowLogKey"></a>
+
+```typescript
+public readonly flowLogKey: IKey;
+```
+
+- *Type:* aws-cdk-lib.aws_kms.IKey
+
+The KMS Key used to encrypt VPC flow logs.
+
+---
+
+##### `flowLogRole`<sup>Required</sup> <a name="flowLogRole" id="aws-dsf.utils.DataVpc.property.flowLogRole"></a>
+
+```typescript
+public readonly flowLogRole: IRole;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+
+The IAM role used to publish VPC Flow Logs.
+
+---
+
+##### `s3VpcEndpoint`<sup>Required</sup> <a name="s3VpcEndpoint" id="aws-dsf.utils.DataVpc.property.s3VpcEndpoint"></a>
+
+```typescript
+public readonly s3VpcEndpoint: IGatewayVpcEndpoint;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint
+
+The S3 VPC endpoint.
+
+---
+
+##### `vpc`<sup>Required</sup> <a name="vpc" id="aws-dsf.utils.DataVpc.property.vpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IVpc
+
+The amazon VPC created.
+
+---
+
+
 ### PySparkApplicationPackage <a name="PySparkApplicationPackage" id="aws-dsf.processing.PySparkApplicationPackage"></a>
 
 A construct that takes your PySpark application, packages its virtual environment and uploads it along its entrypoint to an Amazon S3 bucket This construct requires Docker daemon installed locally to run.
@@ -4164,11 +4367,15 @@ the EmrEksClusterProps [properties]{@link EmrEksClusterProps } if created.
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.ec2InstanceNodeGroupRole">ec2InstanceNodeGroupRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | IAM role used by the tooling managed nodegroup hosting core Kubernetes controllers like EBS CSI driver, core dns. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.eksCluster">eksCluster</a></code> | <code>aws-cdk-lib.aws_eks.Cluster</code> | The EKS cluster created by the construct if it is not provided. |
+| <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC used by the EKS cluster. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.assetBucket">assetBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The bucket holding podtemplates referenced in the configuration override for the job. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.awsNodeRole">awsNodeRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | IAM Role used by IRSA for the aws-node daemonset. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.criticalDefaultConfig">criticalDefaultConfig</a></code> | <code>string</code> | The configuration override for the spark application to use with the default nodes for criticale jobs. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.csiDriverIrsa">csiDriverIrsa</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | *No description.* |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.csiDriverIrsaRole">csiDriverIrsaRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM Role created for the EBS CSI controller. |
+| <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.flowLogGroup">flowLogGroup</a></code> | <code>aws-cdk-lib.aws_logs.ILogGroup</code> | The CloudWatch Log Group for the VPC flow log when the VPC is created. |
+| <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.flowLogKey">flowLogKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS Key used for the VPC flow log when the VPC is created. |
+| <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.flowLogRole">flowLogRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM Role used for the VPC flow log when the VPC is created. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.karpenterEventRules">karpenterEventRules</a></code> | <code>aws-cdk-lib.aws_events.IRule[]</code> | Rules used by Karpenter to track node health, rules are defined in the cloudformation below https://raw.githubusercontent.com/aws/karpenter/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.karpenterIrsaRole">karpenterIrsaRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM role created for the Karpenter controller. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.karpenterQueue">karpenterQueue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | SQS queue used by Karpenter to receive critical events from AWS services which may affect your nodes. |
@@ -4180,6 +4387,7 @@ the EmrEksClusterProps [properties]{@link EmrEksClusterProps } if created.
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.podTemplateS3LocationExecutorShared">podTemplateS3LocationExecutorShared</a></code> | <code>string</code> | The s3 location holding the executor pod tempalte for shared nodes. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.podTemplateS3LocationNotebookDriver">podTemplateS3LocationNotebookDriver</a></code> | <code>string</code> | The s3 location holding the driver pod tempalte for interactive sessions. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.podTemplateS3LocationNotebookExecutor">podTemplateS3LocationNotebookExecutor</a></code> | <code>string</code> | The s3 location holding the executor pod tempalte for interactive sessions. |
+| <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.s3VpcEndpoint">s3VpcEndpoint</a></code> | <code>aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint</code> | The S3 VPC endpoint attached to the private subnets of the VPC when VPC is created. |
 | <code><a href="#aws-dsf.processing.SparkEmrContainersRuntime.property.sharedDefaultConfig">sharedDefaultConfig</a></code> | <code>string</code> | The configuration override for the spark application to use with the default nodes for none criticale jobs. |
 
 ---
@@ -4217,6 +4425,18 @@ public readonly eksCluster: Cluster;
 - *Type:* aws-cdk-lib.aws_eks.Cluster
 
 The EKS cluster created by the construct if it is not provided.
+
+---
+
+##### `vpc`<sup>Required</sup> <a name="vpc" id="aws-dsf.processing.SparkEmrContainersRuntime.property.vpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IVpc
+
+The VPC used by the EKS cluster.
 
 ---
 
@@ -4275,6 +4495,42 @@ public readonly csiDriverIrsaRole: IRole;
 - *Type:* aws-cdk-lib.aws_iam.IRole
 
 The IAM Role created for the EBS CSI controller.
+
+---
+
+##### `flowLogGroup`<sup>Optional</sup> <a name="flowLogGroup" id="aws-dsf.processing.SparkEmrContainersRuntime.property.flowLogGroup"></a>
+
+```typescript
+public readonly flowLogGroup: ILogGroup;
+```
+
+- *Type:* aws-cdk-lib.aws_logs.ILogGroup
+
+The CloudWatch Log Group for the VPC flow log when the VPC is created.
+
+---
+
+##### `flowLogKey`<sup>Optional</sup> <a name="flowLogKey" id="aws-dsf.processing.SparkEmrContainersRuntime.property.flowLogKey"></a>
+
+```typescript
+public readonly flowLogKey: IKey;
+```
+
+- *Type:* aws-cdk-lib.aws_kms.IKey
+
+The KMS Key used for the VPC flow log when the VPC is created.
+
+---
+
+##### `flowLogRole`<sup>Optional</sup> <a name="flowLogRole" id="aws-dsf.processing.SparkEmrContainersRuntime.property.flowLogRole"></a>
+
+```typescript
+public readonly flowLogRole: IRole;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+
+The IAM Role used for the VPC flow log when the VPC is created.
 
 ---
 
@@ -4407,6 +4663,18 @@ public readonly podTemplateS3LocationNotebookExecutor: string;
 - *Type:* string
 
 The s3 location holding the executor pod tempalte for interactive sessions.
+
+---
+
+##### `s3VpcEndpoint`<sup>Optional</sup> <a name="s3VpcEndpoint" id="aws-dsf.processing.SparkEmrContainersRuntime.property.s3VpcEndpoint"></a>
+
+```typescript
+public readonly s3VpcEndpoint: IGatewayVpcEndpoint;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint
+
+The S3 VPC endpoint attached to the private subnets of the VPC when VPC is created.
 
 ---
 
@@ -5172,8 +5440,11 @@ the EMR Serverless aplication ARN, this is used by the method to limit the EMR S
 | <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.application">application</a></code> | <code>aws-cdk-lib.aws_emrserverless.CfnApplication</code> | The EMR Serverless application. |
 | <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.emrApplicationSecurityGroup">emrApplicationSecurityGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | If no VPC is provided, one is created by default along with a security group attached to the EMR Serverless Application This attribute is used to expose the security group, if you provide your own security group through the {@link SparkEmrServerlessRuntimeProps} the attribute will be `undefined`. |
-| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.networkConfiguration">networkConfiguration</a></code> | <code>aws-dsf.utils.NetworkConfiguration</code> | The EMR Serverless application network configuration including VPC, S3 interface endpoint and flow logs. |
-| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.s3GatewayVpcEndpoint">s3GatewayVpcEndpoint</a></code> | <code>aws-cdk-lib.aws_ec2.IVpcEndpoint</code> | If no VPC is provided, one is created by default This attribute is used to expose the Gateway Vpc Endpoint for Amazon S3 The attribute will be undefined if you provided the `networkConfiguration` through the {@link SparkEmrServerlessRuntimeProps}. |
+| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.flowLogGroup">flowLogGroup</a></code> | <code>aws-cdk-lib.aws_logs.ILogGroup</code> | The CloudWatch Log Group for the VPC flow log when the VPC is created. |
+| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.flowLogKey">flowLogKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS Key used for the VPC flow log when the VPC is created. |
+| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.flowLogRole">flowLogRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM Role used for the VPC flow log when the VPC is created. |
+| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.s3VpcEndpoint">s3VpcEndpoint</a></code> | <code>aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint</code> | *No description.* |
+| <code><a href="#aws-dsf.processing.SparkEmrServerlessRuntime.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC used by the EKS cluster. |
 
 ---
 
@@ -5213,27 +5484,61 @@ If no VPC is provided, one is created by default along with a security group att
 
 ---
 
-##### `networkConfiguration`<sup>Optional</sup> <a name="networkConfiguration" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.networkConfiguration"></a>
+##### `flowLogGroup`<sup>Optional</sup> <a name="flowLogGroup" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.flowLogGroup"></a>
 
 ```typescript
-public readonly networkConfiguration: NetworkConfiguration;
+public readonly flowLogGroup: ILogGroup;
 ```
 
-- *Type:* aws-dsf.utils.NetworkConfiguration
+- *Type:* aws-cdk-lib.aws_logs.ILogGroup
 
-The EMR Serverless application network configuration including VPC, S3 interface endpoint and flow logs.
+The CloudWatch Log Group for the VPC flow log when the VPC is created.
 
 ---
 
-##### `s3GatewayVpcEndpoint`<sup>Optional</sup> <a name="s3GatewayVpcEndpoint" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.s3GatewayVpcEndpoint"></a>
+##### `flowLogKey`<sup>Optional</sup> <a name="flowLogKey" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.flowLogKey"></a>
 
 ```typescript
-public readonly s3GatewayVpcEndpoint: IVpcEndpoint;
+public readonly flowLogKey: IKey;
 ```
 
-- *Type:* aws-cdk-lib.aws_ec2.IVpcEndpoint
+- *Type:* aws-cdk-lib.aws_kms.IKey
 
-If no VPC is provided, one is created by default This attribute is used to expose the Gateway Vpc Endpoint for Amazon S3 The attribute will be undefined if you provided the `networkConfiguration` through the {@link SparkEmrServerlessRuntimeProps}.
+The KMS Key used for the VPC flow log when the VPC is created.
+
+---
+
+##### `flowLogRole`<sup>Optional</sup> <a name="flowLogRole" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.flowLogRole"></a>
+
+```typescript
+public readonly flowLogRole: IRole;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+
+The IAM Role used for the VPC flow log when the VPC is created.
+
+---
+
+##### `s3VpcEndpoint`<sup>Optional</sup> <a name="s3VpcEndpoint" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.s3VpcEndpoint"></a>
+
+```typescript
+public readonly s3VpcEndpoint: IGatewayVpcEndpoint;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint
+
+---
+
+##### `vpc`<sup>Optional</sup> <a name="vpc" id="aws-dsf.processing.SparkEmrServerlessRuntime.property.vpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IVpc
+
+The VPC used by the EKS cluster.
 
 ---
 
@@ -6505,6 +6810,81 @@ public readonly silverBucketName: string;
 Name of the Silver bucket.
 
 Use `BucketUtils.generateUniqueBucketName()` to generate a unique name (recommended).
+
+---
+
+### DataVpcProps <a name="DataVpcProps" id="aws-dsf.utils.DataVpcProps"></a>
+
+The properties for the DataVpc construct.
+
+#### Initializer <a name="Initializer" id="aws-dsf.utils.DataVpcProps.Initializer"></a>
+
+```typescript
+import { utils } from 'aws-dsf'
+
+const dataVpcProps: utils.DataVpcProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#aws-dsf.utils.DataVpcProps.property.vpcCidr">vpcCidr</a></code> | <code>string</code> | The CIDR to use to create the subnets in the VPC. |
+| <code><a href="#aws-dsf.utils.DataVpcProps.property.flowLogKey">flowLogKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS key for the VPC flow log group. |
+| <code><a href="#aws-dsf.utils.DataVpcProps.property.flowLogRole">flowLogRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM role for the VPC flow log. |
+| <code><a href="#aws-dsf.utils.DataVpcProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Policy to apply when the bucket is removed from this stack. |
+
+---
+
+##### `vpcCidr`<sup>Required</sup> <a name="vpcCidr" id="aws-dsf.utils.DataVpcProps.property.vpcCidr"></a>
+
+```typescript
+public readonly vpcCidr: string;
+```
+
+- *Type:* string
+
+The CIDR to use to create the subnets in the VPC.
+
+---
+
+##### `flowLogKey`<sup>Optional</sup> <a name="flowLogKey" id="aws-dsf.utils.DataVpcProps.property.flowLogKey"></a>
+
+```typescript
+public readonly flowLogKey: IKey;
+```
+
+- *Type:* aws-cdk-lib.aws_kms.IKey
+- *Default:* A new KMS key is created
+
+The KMS key for the VPC flow log group.
+
+---
+
+##### `flowLogRole`<sup>Optional</sup> <a name="flowLogRole" id="aws-dsf.utils.DataVpcProps.property.flowLogRole"></a>
+
+```typescript
+public readonly flowLogRole: IRole;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+- *Default:* A new IAM role is created
+
+The IAM role for the VPC flow log.
+
+---
+
+##### `removalPolicy`<sup>Optional</sup> <a name="removalPolicy" id="aws-dsf.utils.DataVpcProps.property.removalPolicy"></a>
+
+```typescript
+public readonly removalPolicy: RemovalPolicy;
+```
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+Policy to apply when the bucket is removed from this stack.
+
+* @default - RETAIN (The bucket will be orphaned).
 
 ---
 

--- a/framework/API.md
+++ b/framework/API.md
@@ -6831,8 +6831,9 @@ const dataVpcProps: utils.DataVpcProps = { ... }
 | --- | --- | --- |
 | <code><a href="#aws-dsf.utils.DataVpcProps.property.vpcCidr">vpcCidr</a></code> | <code>string</code> | The CIDR to use to create the subnets in the VPC. |
 | <code><a href="#aws-dsf.utils.DataVpcProps.property.flowLogKey">flowLogKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS key for the VPC flow log group. |
+| <code><a href="#aws-dsf.utils.DataVpcProps.property.flowLogRetention">flowLogRetention</a></code> | <code>aws-cdk-lib.aws_logs.RetentionDays</code> | The retention period to apply to VPC Flow Logs. |
 | <code><a href="#aws-dsf.utils.DataVpcProps.property.flowLogRole">flowLogRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM role for the VPC flow log. |
-| <code><a href="#aws-dsf.utils.DataVpcProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Policy to apply when the bucket is removed from this stack. |
+| <code><a href="#aws-dsf.utils.DataVpcProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | The policy to apply when the bucket is removed from this stack. |
 
 ---
 
@@ -6861,6 +6862,19 @@ The KMS key for the VPC flow log group.
 
 ---
 
+##### `flowLogRetention`<sup>Optional</sup> <a name="flowLogRetention" id="aws-dsf.utils.DataVpcProps.property.flowLogRetention"></a>
+
+```typescript
+public readonly flowLogRetention: RetentionDays;
+```
+
+- *Type:* aws-cdk-lib.aws_logs.RetentionDays
+- *Default:* One week retention
+
+The retention period to apply to VPC Flow Logs.
+
+---
+
 ##### `flowLogRole`<sup>Optional</sup> <a name="flowLogRole" id="aws-dsf.utils.DataVpcProps.property.flowLogRole"></a>
 
 ```typescript
@@ -6881,10 +6895,9 @@ public readonly removalPolicy: RemovalPolicy;
 ```
 
 - *Type:* aws-cdk-lib.RemovalPolicy
+- *Default:* RETAIN (The bucket will be orphaned).
 
-Policy to apply when the bucket is removed from this stack.
-
-* @default - RETAIN (The bucket will be orphaned).
+The policy to apply when the bucket is removed from this stack.
 
 ---
 

--- a/framework/API.md
+++ b/framework/API.md
@@ -3482,7 +3482,7 @@ Any object.
 | <code><a href="#aws-dsf.utils.DataVpc.property.flowLogGroup">flowLogGroup</a></code> | <code>aws-cdk-lib.aws_logs.ILogGroup</code> | The CloudWatch Log Group created for the VPC flow logs. |
 | <code><a href="#aws-dsf.utils.DataVpc.property.flowLogKey">flowLogKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS Key used to encrypt VPC flow logs. |
 | <code><a href="#aws-dsf.utils.DataVpc.property.flowLogRole">flowLogRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The IAM role used to publish VPC Flow Logs. |
-| <code><a href="#aws-dsf.utils.DataVpc.property.s3VpcEndpoint">s3VpcEndpoint</a></code> | <code>aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint</code> | The S3 VPC endpoint. |
+| <code><a href="#aws-dsf.utils.DataVpc.property.s3VpcEndpoint">s3VpcEndpoint</a></code> | <code>aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint</code> | The S3 VPC endpoint gateway. |
 | <code><a href="#aws-dsf.utils.DataVpc.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The amazon VPC created. |
 
 ---
@@ -3543,7 +3543,7 @@ public readonly s3VpcEndpoint: IGatewayVpcEndpoint;
 
 - *Type:* aws-cdk-lib.aws_ec2.IGatewayVpcEndpoint
 
-The S3 VPC endpoint.
+The S3 VPC endpoint gateway.
 
 ---
 
@@ -6860,6 +6860,10 @@ public readonly flowLogKey: IKey;
 
 The KMS key for the VPC flow log group.
 
+The resource policy of the key must be configured according to the AWS documentation.
+
+> [(https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)]((https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html))
+
 ---
 
 ##### `flowLogRetention`<sup>Optional</sup> <a name="flowLogRetention" id="aws-dsf.utils.DataVpcProps.property.flowLogRetention"></a>
@@ -6886,6 +6890,10 @@ public readonly flowLogRole: IRole;
 
 The IAM role for the VPC flow log.
 
+The role must be configured as described in the AWS VPC Flow Log documentation.
+
+> [(https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam-role)]((https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam-role))
+
 ---
 
 ##### `removalPolicy`<sup>Optional</sup> <a name="removalPolicy" id="aws-dsf.utils.DataVpcProps.property.removalPolicy"></a>
@@ -6895,7 +6903,7 @@ public readonly removalPolicy: RemovalPolicy;
 ```
 
 - *Type:* aws-cdk-lib.RemovalPolicy
-- *Default:* RETAIN (The bucket will be orphaned).
+- *Default:* RETAIN The resources will not be deleted.
 
 The policy to apply when the bucket is removed from this stack.
 

--- a/framework/src/utils/README.md
+++ b/framework/src/utils/README.md
@@ -1,3 +1,50 @@
+[//]: # (utils.data-vpc)
+# DataVpc
+
+Amazon VPC optimized for data platforms.
+
+## Overview
+
+`DataVpc` construct provides a standard Amazon VPC with best practices for secuity and data platforms implementations:
+- The VPC is created with 3 AZs (one private and one public subnet per AZ) and 3 NAT gateways.
+- The flow logs maaged by a dedicated least-privilege IAM Role. The role can be customized.
+- The flow logs exported to an Amazon CloudWatch LogGroup encrypted with an Amazon KMS customer managed key. The KMS key can be customized.
+- A gateway VPC endpoint is created for S3 access.
+
+## Usage
+
+[example default](./examples/data-vpc-default.lit.ts)
+
+## VPC Flow Logs
+
+The construct logs VPC Flow logs in a Cloudwatch Log Group that is encrypted with a customer managed KMS Key. Exporting VPC Flow Logs to CloudWatch requires an IAM Role. 
+You can customize the VPC Flow Logs management with:
+- your own KMS Key
+- your own IAM Role
+- a custom retention policy
+
+[example custom KMS Key and IAM Role](./examples/data-vpc-flowlog.lit.ts)
+
+## Removal policy
+
+You can specify if the Cloudwatch Log Group and the KMS encryption Key should be deleted when the CDK resource is destroyed using `removalPolicy`. To have an additional layer of protection, we require users to set a global context value for data removal in their CDK applications.
+
+Log group and encryption key can be destroyed when the CDK resource is destroyed only if **both** data vpc removal policy and DSF on AWS global removal policy are set to remove objects.
+
+You can set `@data-solutions-framework-on-aws/removeDataOnDestroy` (`true` or `false`) global data removal policy in `cdk.json`:
+
+```json title="cdk.json"
+{
+  "context": {
+    "@data-solutions-framework-on-aws/removeDataOnDestroy": true
+  }
+}
+```
+
+Or programmatically in your CDK app:
+
+[example object removal](./examples/data-vpc-removal.lit.ts)
+
 [//]: # (utils.customization)
 # Customize DSF on AWS constructs
 

--- a/framework/src/utils/README.md
+++ b/framework/src/utils/README.md
@@ -6,7 +6,8 @@ Amazon VPC optimized for data platforms.
 ## Overview
 
 `DataVpc` construct provides a standard Amazon VPC with best practices for secuity and data platforms implementations:
-- The VPC is created with 3 AZs (one private and one public subnet per AZ) and 3 NAT gateways.
+- The VPC is created with public and private subnets across 3 availability zones (1 of each per AZ) and 3 NAT gateways.
+- VPC CIDR mask should be larger than 28. The CIDR is split between public and private subnets with private subnets being twice as large as public subnet. 
 - The flow logs maaged by a dedicated least-privilege IAM Role. The role can be customized.
 - The flow logs exported to an Amazon CloudWatch LogGroup encrypted with an Amazon KMS customer managed key. The KMS key can be customized.
 - A gateway VPC endpoint is created for S3 access.
@@ -15,13 +16,15 @@ Amazon VPC optimized for data platforms.
 
 [example default](./examples/data-vpc-default.lit.ts)
 
+
 ## VPC Flow Logs
 
 The construct logs VPC Flow logs in a Cloudwatch Log Group that is encrypted with a customer managed KMS Key. Exporting VPC Flow Logs to CloudWatch requires an IAM Role. 
 You can customize the VPC Flow Logs management with:
-- your own KMS Key
-- your own IAM Role
-- a custom retention policy
+- your own KMS Key. Be sure to attach the right permissions to your key. 
+Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) for full description.
+- your own IAM Role. Be sure to configure the proper trust policy and permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam-role) for full description.
+- a custom log retention policy. Default is one week.
 
 [example custom KMS Key and IAM Role](./examples/data-vpc-flowlog.lit.ts)
 

--- a/framework/src/utils/examples/data-vpc-default.lit.ts
+++ b/framework/src/utils/examples/data-vpc-default.lit.ts
@@ -1,0 +1,17 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as dsf from '../../index';
+
+/// !show
+class ExampleDefaultDataVpcStack extends cdk.Stack {
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+        new dsf.utils.DataVpc(this, 'MyDataVpc', {
+            vpcCidr: '10.0.0.0/16',
+        });
+    }
+}
+/// !hide
+
+const app = new cdk.App();
+new ExampleDefaultDataVpcStack(app, 'ExampleDefaultDataVpc');

--- a/framework/src/utils/examples/data-vpc-flowlog.lit.ts
+++ b/framework/src/utils/examples/data-vpc-flowlog.lit.ts
@@ -1,0 +1,28 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as dsf from '../../index';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { Role } from 'aws-cdk-lib/aws-iam';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+
+
+class ExampleDefaultDataVpcStack extends cdk.Stack {
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+/// !show
+        const flowLogKey = Key.fromKeyArn(this, 'FlowLogKey', 'XXXXXXXXXXXXXXXXXXXXXXXX');
+
+        const flowLogRole = Role.fromRoleArn(this, 'FlowLogRole', 'XXXXXXXXXXXXXXXXXXXXXXXX');
+        
+        new dsf.utils.DataVpc(this, 'MyDataVpc', {
+            vpcCidr: '10.0.0.0/16',
+            flowLogKey,
+            flowLogRole,
+            flowLogRetention: RetentionDays.TWO_WEEKS,
+        });
+    }
+}
+/// !hide
+
+const app = new cdk.App();
+new ExampleDefaultDataVpcStack(app, 'ExampleDefaultDataVpc');

--- a/framework/src/utils/examples/data-vpc-removal.lit.ts
+++ b/framework/src/utils/examples/data-vpc-removal.lit.ts
@@ -1,0 +1,23 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as dsf from '../../index';
+import { RemovalPolicy } from 'aws-cdk-lib';
+
+
+class ExampleDefaultDataVpcStack extends cdk.Stack {
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+/// !show
+        // Set context value for global data removal policy
+        this.node.setContext('@data-solutions-framework-on-aws/removeDataOnDestroy', true);
+        
+        new dsf.utils.DataVpc(this, 'MyDataVpc', {
+            vpcCidr: '10.0.0.0/16',
+            removalPolicy: RemovalPolicy.DESTROY
+        });
+    }
+}
+/// !hide
+
+const app = new cdk.App();
+new ExampleDefaultDataVpcStack(app, 'ExampleDefaultDataVpc');

--- a/framework/src/utils/lib/data-vpc-props.ts
+++ b/framework/src/utils/lib/data-vpc-props.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { RemovalPolicy } from 'aws-cdk-lib';
+import { IRole } from 'aws-cdk-lib/aws-iam';
+import { IKey } from 'aws-cdk-lib/aws-kms';
+
+/**
+ * The properties for the DataVpc construct
+ */
+
+export interface DataVpcProps {
+  /**
+     * The CIDR to use to create the subnets in the VPC.
+     */
+  readonly vpcCidr: string;
+  /**
+     * The KMS key for the VPC flow log group
+     * @default - A new KMS key is created
+     */
+  readonly flowLogKey?: IKey;
+  /**
+     * The IAM role for the VPC flow log
+     * @default - A new IAM role is created
+     */
+  readonly flowLogRole?: IRole;
+  /**
+     * Policy to apply when the bucket is removed from this stack.
+     * * @default - RETAIN (The bucket will be orphaned).
+     */
+  readonly removalPolicy?: RemovalPolicy;
+}

--- a/framework/src/utils/lib/data-vpc-props.ts
+++ b/framework/src/utils/lib/data-vpc-props.ts
@@ -4,6 +4,7 @@
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import { IKey } from 'aws-cdk-lib/aws-kms';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 /**
  * The properties for the DataVpc construct
@@ -11,22 +12,27 @@ import { IKey } from 'aws-cdk-lib/aws-kms';
 
 export interface DataVpcProps {
   /**
-     * The CIDR to use to create the subnets in the VPC.
-     */
+   * The CIDR to use to create the subnets in the VPC.
+   */
   readonly vpcCidr: string;
   /**
-     * The KMS key for the VPC flow log group
-     * @default - A new KMS key is created
-     */
+   * The KMS key for the VPC flow log group
+   * @default - A new KMS key is created
+   */
   readonly flowLogKey?: IKey;
   /**
-     * The IAM role for the VPC flow log
-     * @default - A new IAM role is created
-     */
+   * The IAM role for the VPC flow log
+   * @default - A new IAM role is created
+   */
   readonly flowLogRole?: IRole;
   /**
-     * Policy to apply when the bucket is removed from this stack.
-     * * @default - RETAIN (The bucket will be orphaned).
-     */
+   * The retention period to apply to VPC Flow Logs
+   * @default - One week retention
+   */
+  readonly flowLogRetention?: RetentionDays;
+  /**
+   * The policy to apply when the bucket is removed from this stack.
+   * @default - RETAIN (The bucket will be orphaned).
+   */
   readonly removalPolicy?: RemovalPolicy;
 }

--- a/framework/src/utils/lib/data-vpc-props.ts
+++ b/framework/src/utils/lib/data-vpc-props.ts
@@ -16,12 +16,16 @@ export interface DataVpcProps {
    */
   readonly vpcCidr: string;
   /**
-   * The KMS key for the VPC flow log group
+   * The KMS key for the VPC flow log group.
+   * The resource policy of the key must be configured according to the AWS documentation.
+   *  @see @link(https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)
    * @default - A new KMS key is created
    */
   readonly flowLogKey?: IKey;
   /**
-   * The IAM role for the VPC flow log
+   * The IAM role for the VPC flow log.
+   * The role must be configured as described in the AWS VPC Flow Log documentation.
+   * @see @link(https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam-role)
    * @default - A new IAM role is created
    */
   readonly flowLogRole?: IRole;
@@ -32,7 +36,7 @@ export interface DataVpcProps {
   readonly flowLogRetention?: RetentionDays;
   /**
    * The policy to apply when the bucket is removed from this stack.
-   * @default - RETAIN (The bucket will be orphaned).
+   * @default - RETAIN The resources will not be deleted.
    */
   readonly removalPolicy?: RemovalPolicy;
 }

--- a/framework/src/utils/lib/data-vpc.ts
+++ b/framework/src/utils/lib/data-vpc.ts
@@ -1,0 +1,157 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { Stack, Tags } from 'aws-cdk-lib';
+import { FlowLogDestination, GatewayVpcEndpointAwsService, IGatewayVpcEndpoint, IVpc, IpAddresses, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Effect, IRole, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
+import { ILogGroup, LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+import { Context } from './context';
+import { DataVpcProps } from './data-vpc-props';
+
+
+export class DataVpc extends Construct {
+
+  /**
+   * The amazon VPC created
+   */
+  public readonly vpc: IVpc;
+  /**
+   * The KMS Key used to encrypt VPC flow logs
+   */
+  public readonly flowLogKey: IKey;
+  /**
+   * The IAM role used to publish VPC Flow Logs
+   */
+  public readonly flowLogRole: IRole;
+  /**
+   * The CloudWatch Log Group created for the VPC flow logs
+   */
+  public readonly flowLogGroup: ILogGroup;
+  /**
+   * The S3 VPC endpoint
+   */
+  public readonly s3VpcEndpoint: IGatewayVpcEndpoint;
+
+  constructor(scope: Construct, id: string, props: DataVpcProps) {
+
+    super(scope, id);
+
+    const removalPolicy = Context.revertRemovalPolicy(scope, props.removalPolicy);
+
+    this.flowLogKey = props.flowLogKey || new Key(this, 'FlowLogKey', {
+      description: 'vpc-logs-key',
+      enableKeyRotation: true,
+      removalPolicy: removalPolicy,
+    });
+
+    this.flowLogRole = props.flowLogRole || new Role(scope, 'FlowLogRole', {
+      assumedBy: new ServicePrincipal('vpc-flow-logs.amazonaws.com'),
+    });
+
+    const vpcMask = parseInt(props.vpcCidr.split('/')[1]);
+    const smallestVpcCidr: number = 28;
+    if (vpcMask > smallestVpcCidr) {
+      throw new Error(`The VPC netmask should be at least 28, netmask provided is ${vpcMask}`);
+    }
+
+    // Calculate subnet masks based on VPC's mask
+    const publicSubnetMask = vpcMask + 4;
+    const privateSubnetMask = publicSubnetMask + 2; // twice as large as public subnet
+
+    this.vpc = new Vpc(scope, 'Vpc', {
+      ipAddresses: IpAddresses.cidr(props.vpcCidr),
+      maxAzs: 3,
+      natGateways: 3,
+      subnetConfiguration: [
+        {
+          cidrMask: publicSubnetMask,
+          name: 'Public',
+          subnetType: SubnetType.PUBLIC,
+        },
+        {
+          cidrMask: privateSubnetMask,
+          name: 'Private',
+          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        },
+      ],
+    });
+
+    //Create VPC flow log for the VPC
+    this.flowLogGroup = new LogGroup(scope, 'FLowLogGroup', {
+      encryptionKey: this.flowLogKey,
+      retention: RetentionDays.ONE_WEEK,
+      removalPolicy: removalPolicy,
+    });
+
+    //Allow vpc flowlog to access KMS key to encrypt logs
+    this.flowLogKey.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [new ServicePrincipal(`logs.${Stack.of(scope).region}.amazonaws.com`)],
+        actions: [
+          'kms:Encrypt*',
+          'kms:Decrypt*',
+          'kms:ReEncrypt*',
+          'kms:GenerateDataKey*',
+          'kms:Describe*',
+        ],
+        conditions: {
+          ArnLike: {
+            'kms:EncryptionContext:aws:logs:arn': `arn:aws:logs:${Stack.of(scope).region}:${Stack.of(scope).account}:*`,
+          },
+        },
+        resources: ['*'],
+      }),
+    );
+
+    this.vpc.addFlowLog('FlowLog', {
+      destination: FlowLogDestination.toCloudWatchLogs(this.flowLogGroup, this.flowLogRole),
+    });
+
+    // Create a gateway endpoint for S3
+    this.s3VpcEndpoint= this.vpc.addGatewayEndpoint('S3VpcEndpoint', {
+      service: GatewayVpcEndpointAwsService.S3,
+    });
+  }
+
+  /**
+   * Tag the VPC and the subnets
+   * @param key the tag key
+   * @param value the tag value
+   */
+  public tagVpc(key: string, value: string) {
+    // Add tags to subnets
+    for (let subnet of [...this.vpc.publicSubnets, ...this.vpc.privateSubnets]) {
+      Tags.of(subnet).add(key, value);
+    }
+    // Add tags to vpc
+    Tags.of(this.vpc).add(key, value);
+  }
+
+  //   if (eksClusterName) {
+
+  //     // Add tags to subnets
+  //     for (let subnet of [...vpc.publicSubnets, ...vpc.privateSubnets]) {
+  //       Tags.of(subnet).add('karpenter.sh/discovery', eksClusterName);
+  //     }
+
+  //     // Add tags to vpc
+  //     Tags.of(vpc).add('karpenter.sh/discovery', eksClusterName);
+
+  //   }
+
+  //   if (emrAppName) {
+
+  //     // Add tags to subnets
+  //     for (let subnet of [...vpc.publicSubnets, ...vpc.privateSubnets]) {
+  //       Tags.of(subnet).add('use-by', 'emr-serverless');
+  //     }
+
+  //     // Add tags to vpc
+  //     Tags.of(vpc).add('use-by', 'emr-serverless');
+
+  //   }
+  // }
+}

--- a/framework/src/utils/lib/data-vpc.ts
+++ b/framework/src/utils/lib/data-vpc.ts
@@ -40,6 +40,8 @@ export class DataVpc extends Construct {
 
     const removalPolicy = Context.revertRemovalPolicy(scope, props.removalPolicy);
 
+    const retention = props.flowLogRetention || RetentionDays.ONE_WEEK;
+
     this.flowLogKey = props.flowLogKey || new Key(this, 'FlowLogKey', {
       description: 'vpc-logs-key',
       enableKeyRotation: true,
@@ -81,7 +83,7 @@ export class DataVpc extends Construct {
     //Create VPC flow log for the VPC
     this.flowLogGroup = new LogGroup(scope, 'FLowLogGroup', {
       encryptionKey: this.flowLogKey,
-      retention: RetentionDays.ONE_WEEK,
+      retention,
       removalPolicy: removalPolicy,
     });
 

--- a/framework/src/utils/lib/data-vpc.ts
+++ b/framework/src/utils/lib/data-vpc.ts
@@ -30,7 +30,7 @@ export class DataVpc extends Construct {
    */
   public readonly flowLogGroup: ILogGroup;
   /**
-   * The S3 VPC endpoint
+   * The S3 VPC endpoint gateway
    */
   public readonly s3VpcEndpoint: IGatewayVpcEndpoint;
 

--- a/framework/src/utils/lib/index.ts
+++ b/framework/src/utils/lib/index.ts
@@ -11,5 +11,7 @@ export * from './bucket-utils';
 export * from './step-function-utils';
 export * from './utils';
 export * from './vpc-helper';
+export * from './data-vpc';
+export * from './data-vpc-props';
 
 

--- a/framework/test/unit/nag/utils/nag-data-vpc.test.ts
+++ b/framework/test/unit/nag/utils/nag-data-vpc.test.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { App, Aspects, Stack } from 'aws-cdk-lib';
+import { Match, Annotations } from 'aws-cdk-lib/assertions';
+import { AwsSolutionsChecks } from 'cdk-nag';
+import { DataVpc } from '../../../../src/utils';
+
+/**
+ * Nag Tests Tracked Construct
+ *
+ * @group unit/best-practice/data-vpc
+ */
+
+const app = new App();
+const stack = new Stack(app, 'Stack');
+
+const dataVpc = new DataVpc(stack, 'DataVpc', {
+  vpcCidr: '10.0.0.0/16',
+});
+
+dataVpc.tagVpc('test-tag', 'test-value');
+
+Aspects.of(stack).add(new AwsSolutionsChecks());
+
+
+test('No unsuppressed Warnings', () => {
+  const warnings = Annotations.fromStack(stack).findWarning('*', Match.stringLikeRegexp('AwsSolutions-.*'));
+  console.log(warnings);
+  expect(warnings).toHaveLength(0);
+});
+
+test('No unsuppressed Errors', () => {
+  const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('AwsSolutions-.*'));
+  console.log(errors);
+  expect(errors).toHaveLength(0);
+});

--- a/framework/test/unit/processing/spark-runtime-containers.test.ts
+++ b/framework/test/unit/processing/spark-runtime-containers.test.ts
@@ -290,7 +290,7 @@ describe('With default configuration, the construct ', () => {
         },
         {
           Key: 'Name',
-          Value: 'Default/DsfVpc',
+          Value: 'Default/DataPlatform/Vpc',
         },
       ]),
     });
@@ -429,7 +429,6 @@ describe('With default configuration, the construct ', () => {
 
   test('should create a KMS key for encrypting VPC flow logs', () => {
     template.hasResourceProperties('AWS::KMS::Key', {
-      Description: 'log-vpc-key',
       EnableKeyRotation: true,
       KeyPolicy: Match.objectLike({
         Statement: Match.arrayWith([
@@ -709,7 +708,7 @@ describe('With default configuration, the construct ', () => {
         },
       ]),
       VpcId: {
-        Ref: Match.stringLikeRegexp('DsfVpc.*'),
+        Ref: Match.stringLikeRegexp('DataPlatformVpc.*'),
       },
     });
 
@@ -798,7 +797,7 @@ describe('With DESTROY removal policy and global data removal set to TRUE, the c
   test('should create a KMS Key for VPC flow logs with DELETE removal policy', () => {
     template.hasResource('AWS::KMS::Key', {
       Properties: Match.objectLike({
-        Description: 'log-vpc-key',
+        Description: 'vpc-logs-key',
       }),
       UpdateReplacePolicy: 'Delete',
       DeletionPolicy: 'Delete',
@@ -817,9 +816,6 @@ describe('With DESTROY removal policy and global data removal set to TRUE, the c
 
   test('should create a log group for VPC flow log with DELETE removal policy', () => {
     template.hasResource('AWS::Logs::LogGroup', {
-      Properties: Match.objectLike({
-        LogGroupName: '/aws/emr-eks-vpc-flow/data-platform',
-      }),
       UpdateReplacePolicy: 'Delete',
       DeletionPolicy: 'Delete',
     });
@@ -861,7 +857,7 @@ describe('With DESTROY removal policy and global data removal unset, the constru
   test('should create a KMS Key for VPC flow logs with RETAIN removal policy', () => {
     template.hasResource('AWS::KMS::Key', {
       Properties: Match.objectLike({
-        Description: 'log-vpc-key',
+        Description: 'vpc-logs-key',
       }),
       UpdateReplacePolicy: 'Retain',
       DeletionPolicy: 'Retain',
@@ -880,9 +876,6 @@ describe('With DESTROY removal policy and global data removal unset, the constru
 
   test('should create a log group for VPC flow log with RETAIN removal policy', () => {
     template.hasResource('AWS::Logs::LogGroup', {
-      Properties: Match.objectLike({
-        LogGroupName: '/aws/emr-eks-vpc-flow/data-platform',
-      }),
       UpdateReplacePolicy: 'Retain',
       DeletionPolicy: 'Retain',
     });

--- a/framework/test/unit/utils/data-vpc.test.ts
+++ b/framework/test/unit/utils/data-vpc.test.ts
@@ -3,6 +3,7 @@
 
 import { App, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { DataVpc } from '../../../src/utils';
 
 /**
@@ -82,10 +83,37 @@ describe('With default configuration, the construct ', () => {
     });
   });
 
-  test('should create a log group for VPC flow log with RETAIN removal policy', () => {
+  test('should create a log group for VPC flow log with 7 days retention andRETAIN removal policy', () => {
     template.hasResource('AWS::Logs::LogGroup', {
+      Properties: Match.objectLike({
+        RetentionInDays: 7,
+      }),
       UpdateReplacePolicy: 'Retain',
       DeletionPolicy: 'Retain',
+    });
+  });
+});
+
+describe('With default configuration, the construct ', () => {
+
+  const app = new App();
+  const stack = new Stack(app, 'Stack');
+
+  const dataVpc = new DataVpc(stack, 'DataVpc', {
+    vpcCidr: '10.0.0.0/16',
+    flowLogRetention: RetentionDays.TWO_WEEKS,
+  });
+
+  dataVpc.tagVpc('test-tag', 'test-value');
+
+  const template = Template.fromStack(stack);
+  // console.log(JSON.stringify(template.toJSON(), null, 2));
+
+  test('should create a log group for VPC flow log with custom retention period', () => {
+    template.hasResource('AWS::Logs::LogGroup', {
+      Properties: Match.objectLike({
+        RetentionInDays: 14,
+      }),
     });
   });
 });

--- a/framework/test/unit/utils/data-vpc.test.ts
+++ b/framework/test/unit/utils/data-vpc.test.ts
@@ -1,0 +1,160 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import { App, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { DataVpc } from '../../../src/utils';
+
+/**
+ * Tests DataVpc construct
+ *
+ * @group unit/data-vpc
+ */
+
+describe('With default configuration, the construct ', () => {
+
+  const app = new App();
+  const stack = new Stack(app, 'Stack');
+
+  const dataVpc = new DataVpc(stack, 'DataVpc', {
+    vpcCidr: '10.0.0.0/16',
+  });
+
+  dataVpc.tagVpc('test-tag', 'test-value');
+
+  const template = Template.fromStack(stack);
+  // console.log(JSON.stringify(template.toJSON(), null, 2));
+
+  test('should create a VPC with correct CIDR', () => {
+    template.hasResource('AWS::EC2::VPC',
+      Match.objectLike({
+        Properties: {
+          CidrBlock: Match.stringLikeRegexp('10.0.0.0/16'),
+          Tags: Match.arrayWith([
+            Match.objectLike({
+              Key: 'test-tag',
+              Value: 'test-value',
+            }),
+          ]),
+        },
+      }),
+    );
+  });
+
+  test('should create 2 private subnets with tags', () => {
+    template.resourcePropertiesCountIs('AWS::EC2::Subnet', {
+      Tags: Match.arrayWith([
+        Match.objectLike({
+          Key: 'aws-cdk:subnet-type',
+          Value: 'Private',
+        }),
+        Match.objectLike({
+          Key: 'test-tag',
+          Value: 'test-value',
+        }),
+      ]),
+    }, 2);
+  });
+
+  test('should create 2 public subnets with tags', () => {
+    template.resourcePropertiesCountIs('AWS::EC2::Subnet', {
+      Tags: Match.arrayWith([
+        Match.objectLike({
+          Key: 'aws-cdk:subnet-type',
+          Value: 'Public',
+        }),
+        Match.objectLike({
+          Key: 'test-tag',
+          Value: 'test-value',
+        }),
+      ]),
+    }, 2);
+  });
+
+
+  test('should create a KMS key for VPC flow logs encryption with RETAIN removal policy', () => {
+    template.hasResource('AWS::KMS::Key', {
+      Properties: Match.objectLike({
+        Description: 'vpc-logs-key',
+      }),
+      UpdateReplacePolicy: 'Retain',
+      DeletionPolicy: 'Retain',
+    });
+  });
+
+  test('should create a log group for VPC flow log with RETAIN removal policy', () => {
+    template.hasResource('AWS::Logs::LogGroup', {
+      UpdateReplacePolicy: 'Retain',
+      DeletionPolicy: 'Retain',
+    });
+  });
+});
+
+describe('With DESTROY removal policy and global data removal set to TRUE, the construct ', () => {
+
+  const app = new App();
+  const stack = new Stack(app, 'Stack');
+
+  // Set context value for global data removal policy
+  stack.node.setContext('@data-solutions-framework-on-aws/removeDataOnDestroy', true);
+
+  const dataVpc = new DataVpc(stack, 'DataVpc', {
+    vpcCidr: '10.0.0.0/16',
+    removalPolicy: RemovalPolicy.DESTROY,
+  });
+
+  dataVpc.tagVpc('test-tag', 'test-value');
+
+  const template = Template.fromStack(stack);
+  // console.log(JSON.stringify(template.toJSON(), null, 2));
+
+  test('should create a KMS key with DELETE removal policy', () => {
+    template.hasResource('AWS::KMS::Key', {
+      Properties: Match.objectLike({
+        Description: 'vpc-logs-key',
+      }),
+      UpdateReplacePolicy: 'Delete',
+      DeletionPolicy: 'Delete',
+    });
+  });
+
+  test('should create a log group for VPC flow log with DELETE removal policy', () => {
+    template.hasResource('AWS::Logs::LogGroup', {
+      UpdateReplacePolicy: 'Delete',
+      DeletionPolicy: 'Delete',
+    });
+  });
+});
+
+describe('With DESTROY removal policy and global data removal unset, the construct ', () => {
+
+  const app = new App();
+  const stack = new Stack(app, 'Stack');
+
+  const dataVpc = new DataVpc(stack, 'DataVpc', {
+    vpcCidr: '10.0.0.0/16',
+    removalPolicy: RemovalPolicy.DESTROY,
+  });
+
+  dataVpc.tagVpc('test-tag', 'test-value');
+
+  const template = Template.fromStack(stack);
+  // console.log(JSON.stringify(template.toJSON(), null, 2));
+
+  test('should create a KMS key for VPC flow logs encryption with RETAIN removal policy', () => {
+    template.hasResource('AWS::KMS::Key', {
+      Properties: Match.objectLike({
+        Description: 'vpc-logs-key',
+      }),
+      UpdateReplacePolicy: 'Retain',
+      DeletionPolicy: 'Retain',
+    });
+  });
+
+  test('should create a log group for VPC flow log with RETAIN removal policy', () => {
+    template.hasResource('AWS::Logs::LogGroup', {
+      UpdateReplacePolicy: 'Retain',
+      DeletionPolicy: 'Retain',
+    });
+  });
+});

--- a/website/docs/constructs/library/05-Utils/01-data-vpc.mdx
+++ b/website/docs/constructs/library/05-Utils/01-data-vpc.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 4
+sidebar_label: Data VPC
+---
+
+import GeneratedCode from '../generated/_utils-data-vpc.mdx'
+
+# DataVpc
+<GeneratedCode></GeneratedCode>

--- a/website/docs/constructs/library/generated/_utils-data-vpc.mdx
+++ b/website/docs/constructs/library/generated/_utils-data-vpc.mdx
@@ -7,7 +7,8 @@ Amazon VPC optimized for data platforms.
 ## Overview
 
 `DataVpc` construct provides a standard Amazon VPC with best practices for secuity and data platforms implementations:
-- The VPC is created with 3 AZs (one private and one public subnet per AZ) and 3 NAT gateways.
+- The VPC is created with public and private subnets across 3 availability zones (1 of each per AZ) and 3 NAT gateways.
+- VPC CIDR mask should be larger than 28. The CIDR is split between public and private subnets with private subnets being twice as large as public subnet. 
 - The flow logs maaged by a dedicated least-privilege IAM Role. The role can be customized.
 - The flow logs exported to an Amazon CloudWatch LogGroup encrypted with an Amazon KMS customer managed key. The KMS key can be customized.
 - A gateway VPC endpoint is created for S3 access.
@@ -45,13 +46,15 @@ class ExampleDefaultDataVpcStack(cdk.Stack):
   </TabItem>
 </Tabs>
 
+
 ## VPC Flow Logs
 
 The construct logs VPC Flow logs in a Cloudwatch Log Group that is encrypted with a customer managed KMS Key. Exporting VPC Flow Logs to CloudWatch requires an IAM Role. 
 You can customize the VPC Flow Logs management with:
-- your own KMS Key
-- your own IAM Role
-- a custom retention policy
+- your own KMS Key. Be sure to attach the right permissions to your key. 
+Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) for full description.
+- your own IAM Role. Be sure to configure the proper trust policy and permissions. Refer to the [AWS documentation](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam-role) for full description.
+- a custom log retention policy. Default is one week.
 
 <Tabs>
   <TabItem value="typescript" label="TypeScript" default>

--- a/website/docs/constructs/library/generated/_utils-data-vpc.mdx
+++ b/website/docs/constructs/library/generated/_utils-data-vpc.mdx
@@ -1,0 +1,145 @@
+[//]: # (This file is generated, do not modify directly, update the README.md in framework/src/utils)
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Amazon VPC optimized for data platforms.
+
+## Overview
+
+`DataVpc` construct provides a standard Amazon VPC with best practices for secuity and data platforms implementations:
+- The VPC is created with 3 AZs (one private and one public subnet per AZ) and 3 NAT gateways.
+- The flow logs maaged by a dedicated least-privilege IAM Role. The role can be customized.
+- The flow logs exported to an Amazon CloudWatch LogGroup encrypted with an Amazon KMS customer managed key. The KMS key can be customized.
+- A gateway VPC endpoint is created for S3 access.
+
+## Usage
+
+<Tabs>
+  <TabItem value="typescript" label="TypeScript" default>
+
+  ```typescript
+class ExampleDefaultDataVpcStack extends cdk.Stack {
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
+        new dsf.utils.DataVpc(this, 'MyDataVpc', {
+            vpcCidr: '10.0.0.0/16',
+        });
+    }
+}
+  ```
+  
+  ```mdx-code-block
+  
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+  ```python
+class ExampleDefaultDataVpcStack(cdk.Stack):
+    def __init__(self, scope, id):
+        super().__init__(scope, id)
+        dsf.utils.DataVpc(self, "MyDataVpc",
+            vpc_cidr="10.0.0.0/16"
+        )
+  ```
+
+  </TabItem>
+</Tabs>
+
+## VPC Flow Logs
+
+The construct logs VPC Flow logs in a Cloudwatch Log Group that is encrypted with a customer managed KMS Key. Exporting VPC Flow Logs to CloudWatch requires an IAM Role. 
+You can customize the VPC Flow Logs management with:
+- your own KMS Key
+- your own IAM Role
+- a custom retention policy
+
+<Tabs>
+  <TabItem value="typescript" label="TypeScript" default>
+
+  ```typescript
+        const flowLogKey = Key.fromKeyArn(this, 'FlowLogKey', 'XXXXXXXXXXXXXXXXXXXXXXXX');
+
+        const flowLogRole = Role.fromRoleArn(this, 'FlowLogRole', 'XXXXXXXXXXXXXXXXXXXXXXXX');
+
+        new dsf.utils.DataVpc(this, 'MyDataVpc', {
+            vpcCidr: '10.0.0.0/16',
+            flowLogKey,
+            flowLogRole,
+            flowLogRetention: RetentionDays.TWO_WEEKS,
+        });
+    }
+}
+  ```
+  
+  ```mdx-code-block
+  
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+  ```python
+flow_log_key = Key.from_key_arn(self, "FlowLogKey", "XXXXXXXXXXXXXXXXXXXXXXXX")
+
+flow_log_role = Role.from_role_arn(self, "FlowLogRole", "XXXXXXXXXXXXXXXXXXXXXXXX")
+
+dsf.utils.DataVpc(self, "MyDataVpc",
+    vpc_cidr="10.0.0.0/16",
+    flow_log_key=flow_log_key,
+    flow_log_role=flow_log_role,
+    flow_log_retention=RetentionDays.TWO_WEEKS
+)
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Removal policy
+
+You can specify if the Cloudwatch Log Group and the KMS encryption Key should be deleted when the CDK resource is destroyed using `removalPolicy`. To have an additional layer of protection, we require users to set a global context value for data removal in their CDK applications.
+
+Log group and encryption key can be destroyed when the CDK resource is destroyed only if **both** data vpc removal policy and DSF on AWS global removal policy are set to remove objects.
+
+You can set `@data-solutions-framework-on-aws/removeDataOnDestroy` (`true` or `false`) global data removal policy in `cdk.json`:
+
+```json title="cdk.json"
+{
+  "context": {
+    "@data-solutions-framework-on-aws/removeDataOnDestroy": true
+  }
+}
+```
+
+Or programmatically in your CDK app:
+
+<Tabs>
+  <TabItem value="typescript" label="TypeScript" default>
+
+  ```typescript
+        // Set context value for global data removal policy
+        this.node.setContext('@data-solutions-framework-on-aws/removeDataOnDestroy', true);
+
+        new dsf.utils.DataVpc(this, 'MyDataVpc', {
+            vpcCidr: '10.0.0.0/16',
+            removalPolicy: RemovalPolicy.DESTROY
+        });
+    }
+}
+  ```
+  
+  ```mdx-code-block
+  
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+  ```python
+# Set context value for global data removal policy
+self.node.set_context("@data-solutions-framework-on-aws/removeDataOnDestroy", True)
+
+dsf.utils.DataVpc(self, "MyDataVpc",
+    vpc_cidr="10.0.0.0/16",
+    removal_policy=RemovalPolicy.DESTROY
+)
+  ```
+
+  </TabItem>
+</Tabs>
+


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Add a new construct for creating a standard VPC for data platforms including VPC flow logs in CLoudWatch log group and S3 VPC endpoint

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
