### PR TITLE
ci: Fix label-based E2E test workflow

### DIFF
--- a/.github/workflows/on_pull_request_label.yml
+++ b/.github/workflows/on_pull_request_label.yml
@@ -12,10 +12,28 @@ env:
   AWS_REGION: eu-west-1
 
 jobs:  
-  run-e2e-tests-on-request:
+  set-progress-label:
     # Note: env is not available for the job level 'if', so hard coded value here
     if: ${{ github.event.label.name == 'e2e-ready' }}
+    name: Set in-progress label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    steps:
+      - name: Assign label ${{ env.LABEL_TESTING }}
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          script: |
+            github.rest.issues.removeLabel({...context.repo, issue_number: context.issue.number, name: '${{ env.LABEL_READY }}'});
+            try {
+              await github.rest.issues.removeLabel({...context.repo, issue_number: context.issue.number, name: '${{ env.LABEL_COMPLETED }}'});
+            } catch(e) { /* OK to fail, this label might be missing */ }
+            github.rest.issues.addLabels({...context.repo, issue_number: context.issue.number, labels: ['${{ env.LABEL_TESTING }}']});
+  run-e2e-tests-on-request:
     name: Run E2E tests on request
+    needs: set-progress-label
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -27,15 +45,6 @@ jobs:
           suite: [processing, storage, governance, utils]
         fail-fast: false
     steps:
-      - name: Assign label ${{ env.LABEL_TESTING }}
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-        with:
-          script: |
-            github.rest.issues.removeLabel({...context.repo, issue_number: context.issue.number, name: '${{ env.LABEL_READY }}'});
-            try {
-              await github.rest.issues.removeLabel({...context.repo, issue_number: context.issue.number, name: '${{ env.LABEL_COMPLETED }}'});
-            } catch(e) { /* OK to fail, this label might be missing */ }
-            github.rest.issues.addLabels({...context.repo, issue_number: context.issue.number, labels: ['${{ env.LABEL_TESTING }}']});
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
       - name: Setup NodeJS and dependency cache
@@ -58,7 +67,17 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 7200
       - name: Run e2e tests
-        run: cd framework && npx jest --group=e2e/${{ matrix.suite }}
+        run: cd framework && npx jest --group=e2e/${{ matrix.suite }}      
+  set-completed-label:
+    name: Set completed label 
+    needs: run-e2e-tests-on-request
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    steps:
       - name: Assign label ${{ env.LABEL_COMPLETED }}
         if: always()
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1

--- a/.github/workflows/on_pull_request_label.yml
+++ b/.github/workflows/on_pull_request_label.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-duration-seconds: 7200
+          role-duration-seconds: 10800
       - name: Run e2e tests
         run: cd framework && npx jest --group=e2e/${{ matrix.suite }}      
   set-completed-label:


### PR DESCRIPTION
## Description of changes:

This PR fixes the E2E test workflow that triggers the tests based on the label assignment. After introducing the E2E test parallelization in #325, the workflow fails due to a race condition inside of the parallel branches trying to assign/delete the labels. This PR separates the label assignment and the actual parallel test runs.

**Checklist**

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
