### PR TITLE
ci: Improve E2E completed label workflow

### DIFF
--- a/.github/workflows/on_pull_request_label.yml
+++ b/.github/workflows/on_pull_request_label.yml
@@ -70,8 +70,8 @@ jobs:
         run: cd framework && npx jest --group=e2e/${{ matrix.suite }}      
   set-completed-label:
     name: Set completed label 
-    needs: run-e2e-tests-on-request
-    if: always()
+    needs: [set-progress-label, run-e2e-tests-on-request]
+    if: always() && needs.set-progress-label.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -79,9 +79,10 @@ jobs:
       actions: read
     steps:
       - name: Assign label ${{ env.LABEL_COMPLETED }}
-        if: always()
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             github.rest.issues.addLabels({...context.repo, issue_number: context.issue.number, labels: ['${{ env.LABEL_COMPLETED }}']});
-            github.rest.issues.removeLabel({...context.repo, issue_number: context.issue.number, name: '${{ env.LABEL_TESTING }}'});
+            try {
+              await github.rest.issues.removeLabel({...context.repo, issue_number: context.issue.number, name: '${{ env.LABEL_TESTING }}'});
+            } catch(e) { /* OK to fail, this label might be missing when re-running single test-jobs*/ }


### PR DESCRIPTION
## Description of changes:

This PR improves the E2E automated workflow. The missing 'testing' label doesn't cause the workflow to fail anymore. This is for the case a (failed) test job is re-run. In that case, the 'testing' label will be missing, so its absence shouldn't cause the whole workflow to fail.

**Checklist**

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
