### PR TITLE
ci: Fix race condition in examples build

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -260,10 +260,9 @@ sparkDataLakeInfraExampleApp.addTask('test:e2e', {
   description: 'Run end-to-end tests',
   exec: 'pytest -k e2e'
 });
-const synthTask = sparkDataLakeInfraExampleApp.tasks.tryFind('synth:silent');
-synthTask?.reset();
-synthTask?.prependExec(`cdk --version || npm install -g cdk@${CDK_VERSION}`);
-synthTask?.exec('cdk synth -q -c prod=PLACEHOLDER -c staging=PLACEHOLDER');
+const synthTask = sparkDataLakeInfraExampleApp.tasks.tryFind('synth:silent')!;
+synthTask.reset();
+synthTask.exec(`npx aws-cdk@${CDK_VERSION} synth -q -c prod=PLACEHOLDER -c staging=PLACEHOLDER`);
 const buildExampleTask = sparkDataLakeInfraExampleApp.addTask('build-example', {
   steps: [
     { exec: `pip install --ignore-installed --no-deps --no-index --find-links ../../../framework/dist/python aws_dsf` },
@@ -318,10 +317,9 @@ adsfQuickstart.addTask('test:e2e', {
   description: 'Run end-to-end tests',
   exec: 'pytest -k e2e'
 });
-const adsfQuickstartSynthTask = adsfQuickstart.tasks.tryFind('synth:silent');
-adsfQuickstartSynthTask?.reset();
-adsfQuickstartSynthTask?.prependExec(`cdk --version || npm install -g cdk@${CDK_VERSION}`);
-adsfQuickstartSynthTask?.exec('cdk synth -q');
+const adsfQuickstartSynthTask = adsfQuickstart.tasks.tryFind('synth:silent')!;
+adsfQuickstartSynthTask.reset();
+adsfQuickstartSynthTask.exec(`npx aws-cdk@${CDK_VERSION} synth -q`);
 const buildAdsfQuickstartTask = adsfQuickstart.addTask('build-example', {
   steps: [
     { exec: `pip install --ignore-installed --no-deps --no-index --find-links ../../framework/dist/python aws_dsf` },

--- a/examples/dsf-quickstart/.projen/tasks.json
+++ b/examples/dsf-quickstart/.projen/tasks.json
@@ -80,10 +80,7 @@
       "description": "Synthesizes your cdk app into cdk.out and suppresses the template in stdout (part of \"yarn build\")",
       "steps": [
         {
-          "exec": "cdk --version || npm install -g cdk@2.114.1"
-        },
-        {
-          "exec": "cdk synth -q"
+          "exec": "npx aws-cdk@2.114.1 synth -q"
         }
       ]
     },

--- a/examples/spark-data-lake/infra/.projen/tasks.json
+++ b/examples/spark-data-lake/infra/.projen/tasks.json
@@ -80,10 +80,7 @@
       "description": "Synthesizes your cdk app into cdk.out and suppresses the template in stdout (part of \"yarn build\")",
       "steps": [
         {
-          "exec": "cdk --version || npm install -g cdk@2.114.1"
-        },
-        {
-          "exec": "cdk synth -q -c prod=PLACEHOLDER -c staging=PLACEHOLDER"
+          "exec": "npx aws-cdk@2.114.1 synth -q -c prod=PLACEHOLDER -c staging=PLACEHOLDER"
         }
       ]
     },


### PR DESCRIPTION
## Description of changes:

This PR fixes an issue introduced in #191. There is a race condition on examples build that might sometimes cause the build to fail. The parallel building of examples tries to globally install CDK which sometimes results in a race condition. Instead of the global `npm install`, the `npx` execution method is now used.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
