### PR TITLE
ci: ESLint workaround for missing symbols

### DIFF
--- a/framework/eslint-local-rules/rules.ts
+++ b/framework/eslint-local-rules/rules.ts
@@ -29,6 +29,11 @@ export default {
                     const instantiatedType = <ts.Type>typeChecker.getTypeAtLocation(typescriptNode);
                     const baseTypes = instantiatedType.getBaseTypes();
 
+                    if (instantiatedType.symbol == null) {
+                        // Non-nullable 'symbol' property contains null - no analysis possible
+                        return;
+                    }
+
                     if (instantiatedType.symbol.name == 'Construct' || baseTypes && baseTypes.some(t => t.symbol.name == 'Construct')) {
                         if (node.arguments.length <= 1) {
                             // Non-standard schema, expected at least 2 parameters


### PR DESCRIPTION
## Description of changes:

This PR implements a workaround for the custom ESLint rule `no-tokens-in-construct-id`.
The non-nullable `Type.symbol` property still can have `null` values, so this PR introduces an additional check that just ignores such cases (we cannot analyze further anyway).

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
