### PR TITLE
ci: fix github action for e2e

### DIFF
--- a/.github/workflows/on_pull_request_label.yml
+++ b/.github/workflows/on_pull_request_label.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
     strategy:
         matrix:
-          suite: [processing, storage, governance, utils]
+          suite: [processing, storage, governance, utils, consumption]
         fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
     strategy:
         matrix:
-          suite: [processing, storage, governance, utils]
+          suite: [processing, storage, governance, utils, consumption]
         fail-fast: false
     steps:
       - name: Checkout Repo

--- a/framework/test/e2e/redshift-serverless.e2e.test.ts
+++ b/framework/test/e2e/redshift-serverless.e2e.test.ts
@@ -9,7 +9,7 @@ import { RedshiftServerlessNamespace, RedshiftServerlessWorkgroup } from '../../
 
 /**
  * E2E test for RedshiftServerlessWorkgroup
- * @group e2e/redshift-serverless
+ * @group e2e/consumption/redshift-serverless
  */
 
 jest.setTimeout(6000000);


### PR DESCRIPTION
**Issue #, if available:**

Update the github action to run the e2e test for redshift and any consumption layer construct that will be added

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
