### PR TITLE
feat(redshift-serverless): Allow users to take a final snapshot before `RedshiftServerlessNamespace` is deleted

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -10522,6 +10522,8 @@ const redshiftServerlessNamespaceProps: consumption.RedshiftServerlessNamespaceP
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.adminUsername">adminUsername</a></code> | <code>string</code> | The admin username to be used. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.dataKey">dataKey</a></code> | <code>aws-cdk-lib.aws_kms.Key</code> | The KMS Key used to encrypt the data. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.defaultIAMRole">defaultIAMRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | Default IAM Role associated to the Redshift Serverless Namespace. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.finalSnapshotName">finalSnapshotName</a></code> | <code>string</code> | If provided, final snapshot would be taken with the name provided. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.finalSnapshotRetentionPeriod">finalSnapshotRetentionPeriod</a></code> | <code>number</code> | The number of days the final snapshot would be retained. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.iamRoles">iamRoles</a></code> | <code>aws-cdk-lib.aws_iam.IRole[]</code> | List of IAM Roles attached to the Redshift Serverless Namespace. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.logExports">logExports</a></code> | <code>@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceLogExport[]</code> | The type of logs to be exported. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | The removal policy when deleting the CDK resource. |
@@ -10601,6 +10603,34 @@ public readonly defaultIAMRole: IRole;
 - *Default:* No default IAM Role is associated with the Redshift Serverless Namespace
 
 Default IAM Role associated to the Redshift Serverless Namespace.
+
+---
+
+##### `finalSnapshotName`<sup>Optional</sup> <a name="finalSnapshotName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.finalSnapshotName"></a>
+
+```typescript
+public readonly finalSnapshotName: string;
+```
+
+- *Type:* string
+- *Default:* No final snapshot would be taken
+
+If provided, final snapshot would be taken with the name provided.
+
+---
+
+##### `finalSnapshotRetentionPeriod`<sup>Optional</sup> <a name="finalSnapshotRetentionPeriod" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespaceProps.property.finalSnapshotRetentionPeriod"></a>
+
+```typescript
+public readonly finalSnapshotRetentionPeriod: number;
+```
+
+- *Type:* number
+- *Default:* Indefinite final snapshot retention
+
+The number of days the final snapshot would be retained.
+
+Must be between 1-3653 days.
 
 ---
 

--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace-props.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace-props.ts
@@ -71,4 +71,16 @@ export interface RedshiftServerlessNamespaceProps {
    * @default - The resources are not deleted (`RemovalPolicy.RETAIN`).
    */
   readonly removalPolicy?: RemovalPolicy;
+
+  /**
+   * If provided, final snapshot would be taken with the name provided.
+   * @default No final snapshot would be taken
+   */
+  readonly finalSnapshotName?: string;
+
+  /**
+   * The number of days the final snapshot would be retained. Must be between 1-3653 days.
+   * @default Indefinite final snapshot retention
+   */
+  readonly finalSnapshotRetentionPeriod?: number;
 }

--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace.ts
@@ -132,6 +132,8 @@ export class RedshiftServerlessNamespace extends TrackedConstruct {
       manageAdminPassword: true,
       logExports,
       indexParameterName,
+      finalSnapshotName: props.finalSnapshotName,
+      finalSnapshotRetentionPeriod: props.finalSnapshotRetentionPeriod,
     };
 
     const roleArns = Object.keys(this.roles);

--- a/framework/src/consumption/lib/redshift/resources/RedshiftServerlessNamespace/index.mjs
+++ b/framework/src/consumption/lib/redshift/resources/RedshiftServerlessNamespace/index.mjs
@@ -118,7 +118,20 @@ export const handler = async(event) => {
   } else if (requestType === "Update") {
     return await handleUpdate(event)
   } else if (requestType === "Delete") {
-    await client.send(new DeleteNamespaceCommand({"namespaceName": resourceProperties["namespaceName"]}))
+    const deletePayload = {
+      "namespaceName": resourceProperties["namespaceName"]
+    }
+
+    if (resourceProperties["finalSnapshotName"]) {
+       deletePayload.finalSnapshotName = resourceProperties["finalSnapshotName"]
+
+       if (resourceProperties["finalSnapshotRetentionPeriod"]) {
+        deletePayload.finalSnapshotRetentionPeriod = parseInt(resourceProperties["finalSnapshotRetentionPeriod"])
+       }
+       
+    }
+
+    await client.send(new DeleteNamespaceCommand(deletePayload))
     
     return
   }

--- a/framework/test/unit/consumption/redshift-serverless-namespace.test.ts
+++ b/framework/test/unit/consumption/redshift-serverless-namespace.test.ts
@@ -343,3 +343,23 @@ describe('With global removal policy set to DELETE, the construct ', () => {
     });
   });
 });
+
+describe('With final snapshot configuration, the construct ', () => {
+  const stack = new Stack();
+
+  new RedshiftServerlessNamespace(stack, 'DefaultNamespace', {
+    dbName: 'defaultdb',
+    name: 'defaultnamespace',
+    finalSnapshotName: 'defaultnamespace-snapshot',
+    finalSnapshotRetentionPeriod: 10,
+  });
+
+  const template = Template.fromStack(stack);
+
+  test('should create resource with final snapshot configuration in place', () => {
+    template.hasResourceProperties('Custom::RedshiftServerlessNamespace', {
+      finalSnapshotName: Match.exact('defaultnamespace-snapshot'),
+      finalSnapshotRetentionPeriod: Match.exact(10),
+    });
+  });
+});


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Users can now configure Redshift Serverless to create a final snapshot when stack is deleted

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
