### PR TITLE
fix: IAM role for redshift namespace CR

### DIFF
--- a/framework/src/consumption/lib/redshift-serverless/redshift-serverless-namespace.ts
+++ b/framework/src/consumption/lib/redshift-serverless/redshift-serverless-namespace.ts
@@ -196,9 +196,21 @@ export class RedshiftServerlessNamespace extends TrackedConstruct {
         ],
         resources: [this.dataKey.keyArn, this.adminSecretKey.keyArn],
       }),
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          'iam:CreateServiceLinkedRole',
+        ],
+        resources: [`arn:aws:iam::${Stack.of(this).account}:role/aws-service-role/redshift.amazonaws.com/AWSServiceRoleForRedshift`],
+        conditions: {
+          StringEquals: {
+            'iam:AWSServiceName': 'redshift.amazonaws.com',
+          },
+        },
+      }),
     ];
 
-    // If there are IAM Roles to configure in the namespace, we grant to the custom resource pass role for these roles
+    // If there are IAM Roles to configure in the namespace, we grant pass role for these roles to the custom resource
     if (roleArns && roleArns.length > 0) {
       createNamespaceCrPolicyStatements.push(new PolicyStatement({
         effect: Effect.ALLOW,

--- a/framework/test/unit/consumption/redshift-serverless-namespace.test.ts
+++ b/framework/test/unit/consumption/redshift-serverless-namespace.test.ts
@@ -161,6 +161,26 @@ describe('With default configuration, the construct', () => {
                   },
                 ],
               },
+              {
+                Action: 'iam:CreateServiceLinkedRole',
+                Condition: {
+                  StringEquals: {
+                    'iam:AWSServiceName': 'redshift.amazonaws.com',
+                  },
+                },
+                Effect: 'Allow',
+                Resource: {
+                  'Fn::Join': Match.arrayWith([
+                    [
+                      'arn:aws:iam::',
+                      {
+                        Ref: 'AWS::AccountId',
+                      },
+                      ':role/aws-service-role/redshift.amazonaws.com/AWSServiceRoleForRedshift',
+                    ],
+                  ]),
+                },
+              },
             ],
           }),
           PolicyName: 'PrimaryPermissions',


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Give IAM permissions for creating the Redshift Serverless service linked role

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [x] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
