### PR TITLE
fix: configure bucket key by default

### DIFF
--- a/framework/src/storage/lib/analytics-bucket.ts
+++ b/framework/src/storage/lib/analytics-bucket.ts
@@ -47,6 +47,7 @@ export class AnalyticsBucket extends Bucket {
       blockPublicAccess: props?.blockPublicAccess || BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
       encryption: BucketEncryption.KMS,
+      bucketKeyEnabled: true,
       lifecycleRules: props?.lifecycleRules?.concat(AnalyticsBucket.LIFECYCLE_RULE) || AnalyticsBucket.LIFECYCLE_RULE,
       removalPolicy,
       serverAccessLogsPrefix: props?.serverAccessLogsPrefix || bucketName,

--- a/framework/test/unit/storage/analytics-bucket.test.ts
+++ b/framework/test/unit/storage/analytics-bucket.test.ts
@@ -39,6 +39,7 @@ describe('AnalyticsBucket Construct with default configuration', () => {
           BucketEncryption: {
             ServerSideEncryptionConfiguration: [
               {
+                BucketKeyEnabled: true,
                 ServerSideEncryptionByDefault: {
                   SSEAlgorithm: 'aws:kms',
                 },


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Change default configuration for the bucket Key in the `AnalyticsBucket` construct

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
