### PR TITLE
fix: change permissions for Glue crawler in DataCatalogDatabase

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -8778,7 +8778,7 @@ public readonly locationPrefix: string;
 
 Top level location where table data is stored.
 
-The location prefix cannot be empty if the `locationBucket` is set. 
+The location prefix cannot be empty if the `locationBucket` is set.
 The minimal configuration is `/` for the root level in the Bucket.
 
 ---

--- a/framework/API.md
+++ b/framework/API.md
@@ -8618,7 +8618,7 @@ const dataCatalogDatabaseProps: governance.DataCatalogDatabaseProps = { ... }
 | <code><a href="#@cdklabs/aws-data-solutions-framework.governance.DataCatalogDatabaseProps.property.jdbcSecret">jdbcSecret</a></code> | <code>aws-cdk-lib.aws_secretsmanager.ISecret</code> | The secret associated with the JDBC connection. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.governance.DataCatalogDatabaseProps.property.jdbcSecretKMSKey">jdbcSecretKMSKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The KMS key used by the JDBC secret. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.governance.DataCatalogDatabaseProps.property.locationBucket">locationBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket where data is stored. |
-| <code><a href="#@cdklabs/aws-data-solutions-framework.governance.DataCatalogDatabaseProps.property.locationPrefix">locationPrefix</a></code> | <code>string</code> | Top level location wwhere table data is stored. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.governance.DataCatalogDatabaseProps.property.locationPrefix">locationPrefix</a></code> | <code>string</code> | Top level location where table data is stored. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.governance.DataCatalogDatabaseProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | The removal policy when deleting the CDK resource. |
 
 ---
@@ -8776,7 +8776,10 @@ public readonly locationPrefix: string;
 
 - *Type:* string
 
-Top level location wwhere table data is stored.
+Top level location where table data is stored.
+
+The location prefix cannot be empty if the `locationBucket` is set. 
+The minimal configuration is `/` for the root level in the Bucket.
 
 ---
 

--- a/framework/src/governance/lib/data-catalog-database-props.ts
+++ b/framework/src/governance/lib/data-catalog-database-props.ts
@@ -23,7 +23,9 @@ export interface DataCatalogDatabaseProps {
   readonly locationBucket?: IBucket;
 
   /**
-   * Top level location wwhere table data is stored.
+   * Top level location where table data is stored.
+   * The location prefix cannot be empty if the `locationBucket` is set.
+   * The minimal configuration is `/` for the root level in the Bucket.
    */
   readonly locationPrefix?: string;
 

--- a/framework/src/governance/lib/data-catalog-database.ts
+++ b/framework/src/governance/lib/data-catalog-database.ts
@@ -309,7 +309,8 @@ export class DataCatalogDatabase extends TrackedConstruct {
    */
   private handleS3TypeCrawler(props: DataCatalogDatabaseProps, s3Props: S3CrawlerProps): CfnCrawler {
     const tableLevel = props.crawlerTableLevelDepth || this.calculateDefaultTableLevelDepth(s3Props.locationPrefix);
-    props.locationBucket!.grantRead(this.crawlerRole!, s3Props.locationPrefix+'*');
+    const grantPrefix = s3Props.locationPrefix == '/' ? '' : s3Props.locationPrefix;
+    props.locationBucket!.grantRead(this.crawlerRole!, grantPrefix+'*');
 
     return new CfnCrawler(this, 'DatabaseAutoCrawler', {
       role: this.crawlerRole!.roleArn,


### PR DESCRIPTION
…tructure

**Issue #, if available:**

## Description of changes:

fix permissions for Glue crawler in `DataCatalogDatabase` in the edge case of flat data lake structure

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
