### PR TITLE
fix: fix resource quota issue in spark-containers

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -9775,6 +9775,7 @@ const emrVirtualClusterProps: processing.EmrVirtualClusterProps = { ... }
 | <code><a href="#@cdklabs/aws-data-solutions-framework.processing.EmrVirtualClusterProps.property.name">name</a></code> | <code>string</code> | The name of the Amazon EMR Virtual Cluster to be created. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.processing.EmrVirtualClusterProps.property.createNamespace">createNamespace</a></code> | <code>boolean</code> | The flag to create EKS namespace. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.processing.EmrVirtualClusterProps.property.eksNamespace">eksNamespace</a></code> | <code>string</code> | The name of the EKS namespace to be linked to the EMR virtual cluster. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.processing.EmrVirtualClusterProps.property.setNamespaceResourceQuota">setNamespaceResourceQuota</a></code> | <code>boolean</code> | The namespace will be create with ResourceQuota and LimitRange As defined here https://github.com/awslabs/data-solutions-framework-on-aws/blob/main/framework/src/processing/lib/spark-runtime/emr-containers/resources/k8s/resource-management.yaml. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.processing.EmrVirtualClusterProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | The tags assigned to the Virtual Cluster. |
 
 ---
@@ -9814,6 +9815,19 @@ public readonly eksNamespace: string;
 - *Default:* Use the default namespace
 
 The name of the EKS namespace to be linked to the EMR virtual cluster.
+
+---
+
+##### `setNamespaceResourceQuota`<sup>Optional</sup> <a name="setNamespaceResourceQuota" id="@cdklabs/aws-data-solutions-framework.processing.EmrVirtualClusterProps.property.setNamespaceResourceQuota"></a>
+
+```typescript
+public readonly setNamespaceResourceQuota: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+The namespace will be create with ResourceQuota and LimitRange As defined here https://github.com/awslabs/data-solutions-framework-on-aws/blob/main/framework/src/processing/lib/spark-runtime/emr-containers/resources/k8s/resource-management.yaml.
 
 ---
 

--- a/framework/src/processing/lib/spark-runtime/emr-containers/emr-virtual-cluster-props.ts
+++ b/framework/src/processing/lib/spark-runtime/emr-containers/emr-virtual-cluster-props.ts
@@ -22,6 +22,13 @@ export interface EmrVirtualClusterProps {
   readonly createNamespace?: boolean;
 
   /**
+   * The namespace will be create with ResourceQuota and LimitRange
+   * As defined here https://github.com/awslabs/data-solutions-framework-on-aws/blob/main/framework/src/processing/lib/spark-runtime/emr-containers/resources/k8s/resource-management.yaml
+   * @default - true
+   */
+  readonly setNamespaceResourceQuota?: boolean;
+
+  /**
    * The tags assigned to the Virtual Cluster
    *
    * @default - none

--- a/framework/src/processing/lib/spark-runtime/emr-containers/resources/k8s/resource-management.yaml
+++ b/framework/src/processing/lib/spark-runtime/emr-containers/resources/k8s/resource-management.yaml
@@ -20,6 +20,8 @@ spec:
   limits:
   - min:
       cpu: "100m"
+      memory: 100Mi
     defaultRequest:
       cpu: "100m"
+      memory: 100Mi
     type: Container

--- a/framework/src/processing/lib/spark-runtime/emr-containers/spark-emr-containers-runtime.ts
+++ b/framework/src/processing/lib/spark-runtime/emr-containers/spark-emr-containers-runtime.ts
@@ -573,9 +573,10 @@ export class SparkEmrContainersRuntime extends TrackedConstruct {
     const eksNamespace = options.eksNamespace ?? 'default';
 
     let ns = undefined;
+    let setNamespaceResourceQuota = options.setNamespaceResourceQuota == undefined ? true : options.setNamespaceResourceQuota;
 
     if (options.createNamespace) {
-      ns = createNamespace(this.eksCluster, options.eksNamespace!);
+      ns = createNamespace(this.eksCluster, options.eksNamespace!, setNamespaceResourceQuota);
     }
 
     // deep clone the Role Binding template object and replace the namespace

--- a/framework/test/unit/processing/spark-runtime-containers.test.ts
+++ b/framework/test/unit/processing/spark-runtime-containers.test.ts
@@ -960,6 +960,9 @@ describe('Test for interactive endpoint', () => {
 
   const virtualCluster = emrEksCluster.addEmrVirtualCluster(emrEksClusterStack, {
     name: 'test',
+    setNamespaceResourceQuota: true,
+    eksNamespace: 'spark',
+    createNamespace: true,
   });
 
   const policy = new ManagedPolicy(emrEksClusterStack, 'testPolicy', {
@@ -999,6 +1002,10 @@ describe('Test for interactive endpoint', () => {
         default: {},
       }),
     });
+  });
+
+  template.hasResourceProperties ('Custom::AWSCDK-EKS-KubernetesResource', {
+    Manifest: Match.stringLikeRegexp('.*?100Mi.*'),
   });
 
   test('should create an interactive endpoint with provided name and provided emr runtime', () => {


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Currently the Resourcequota and Limit range cause jobs to fail if they are run with the default pod template when using init/sidecar containers. This PR allow the user to opt-out of Resourcequota and Limit range set by default and address the issue by addition of limit range on memory.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
