### PR TITLE
test: add random eks name to e2e test

### DIFF
--- a/framework/test/e2e/spark-emr-containers.e2e.test.ts
+++ b/framework/test/e2e/spark-emr-containers.e2e.test.ts
@@ -14,6 +14,7 @@ import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { JsonPath } from 'aws-cdk-lib/aws-stepfunctions';
 import { TestStack } from './test-stack';
 import { SparkEmrContainersJob, SparkEmrContainersRuntime } from '../../src/processing';
+import { Utils } from '../../src/utils';
 
 
 jest.setTimeout(10000000);
@@ -30,6 +31,7 @@ const eksAdminRole = Role.fromRoleArn(stack, 'EksAdminRole', `arn:aws:iam::${sta
 
 // creation of the construct(s) under test
 const emrEksCluster = SparkEmrContainersRuntime.getOrCreate(stack, {
+  eksClusterName: Utils.generateUniqueHash(stack, cdk.Stack.of(stack).stackName.slice(0, 5)),
   eksAdminRole,
   publicAccessCIDRs: ['10.0.0.0/32'],
   createEmrOnEksServiceLinkedRole: false,
@@ -51,7 +53,7 @@ const s3ReadPolicy = new ManagedPolicy(stack, 's3ReadPolicy', {
 });
 
 const virtualCluster = emrEksCluster.addEmrVirtualCluster(stack, {
-  name: 'e2etest',
+  name: `e2etest${cdk.Stack.of(stack).stackName.slice(0, 5)}`,
   createNamespace: true,
   eksNamespace: 'e2etestns',
 });

--- a/framework/test/e2e/spark-emr-containers.e2e.test.ts
+++ b/framework/test/e2e/spark-emr-containers.e2e.test.ts
@@ -60,7 +60,7 @@ const virtualCluster = emrEksCluster.addEmrVirtualCluster(stack, {
   eksNamespace: 'e2etestns',
 });
 
-const execRole = emrEksCluster.createExecutionRole(stack, 'ExecRole', s3ReadPolicy, 'e2ens', 's3ReadExecRole');
+const execRole = emrEksCluster.createExecutionRole(stack, 'ExecRole', s3ReadPolicy, 'e2ens', `s3ReadExecRole${randomName}`);
 
 const logBucket = new Bucket(stack, 'Bucket', {
   removalPolicy: cdk.RemovalPolicy.DESTROY,

--- a/framework/test/e2e/spark-emr-containers.e2e.test.ts
+++ b/framework/test/e2e/spark-emr-containers.e2e.test.ts
@@ -29,9 +29,11 @@ stack.node.setContext('@data-solutions-framework-on-aws/removeDataOnDestroy', tr
 const kubectlLayer = new KubectlV27Layer(stack, 'kubectlLayer');
 const eksAdminRole = Role.fromRoleArn(stack, 'EksAdminRole', `arn:aws:iam::${stack.account}:role/role-name-with-path`);
 
+const randomName = Utils.generateUniqueHash(stack, cdk.Stack.of(stack).stackName.slice(0, 5));
+
 // creation of the construct(s) under test
 const emrEksCluster = SparkEmrContainersRuntime.getOrCreate(stack, {
-  eksClusterName: Utils.generateUniqueHash(stack, cdk.Stack.of(stack).stackName.slice(0, 5)),
+  eksClusterName: randomName,
   eksAdminRole,
   publicAccessCIDRs: ['10.0.0.0/32'],
   createEmrOnEksServiceLinkedRole: false,
@@ -53,7 +55,7 @@ const s3ReadPolicy = new ManagedPolicy(stack, 's3ReadPolicy', {
 });
 
 const virtualCluster = emrEksCluster.addEmrVirtualCluster(stack, {
-  name: `e2etest${cdk.Stack.of(stack).stackName.slice(0, 5)}`,
+  name: `e2etest${randomName}`,
   createNamespace: true,
   eksNamespace: 'e2etestns',
 });


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Currently in e2e test if the stack for `spark-conatiners` fails and does not delete cleanly the subsqueent e2e test will fail because the EKS cluster has the same name.  This PR add a randomized name.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
