### PR TITLE
fix(kafka-api):Add esbuild install part of provider bundling options

### DIFF
--- a/framework/src/streaming/lib/msk/msk-helpers.ts
+++ b/framework/src/streaming/lib/msk/msk-helpers.ts
@@ -92,6 +92,14 @@ export function mskIamCrudProviderSetup(
           'aws-msk-iam-sasl-signer-js',
           'kafkajs',
         ],
+        commandHooks: {
+          afterBundling: () => [],
+          beforeBundling: () => [
+            // Manually force esbuild to be installed for bundling to work properly
+            'npx esbuild --version',
+          ],
+          beforeInstall: () => [],
+        },
       },
       iamRole: iamHandlerRole,
     },
@@ -172,6 +180,14 @@ export function mskAclAdminProviderSetup(
         nodeModules: [
           'kafkajs',
         ],
+        commandHooks: {
+          afterBundling: () => [],
+          beforeBundling: () => [
+            // Manually force esbuild to be installed for bundling to work properly
+            'npx esbuild --version',
+          ],
+          beforeInstall: () => [],
+        },
       },
       iamRole: mtlsHandlerRole,
     },


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

When `esbuild` is not available in the local environment, CDK uses a container to run the bundling, in some edge cases, the Docker used to bundle fail. This PR add the install of `esbuild` to the local system as part of the provider bundling option, by leveraging the command hooks in the NodeJsFunction Bundling option.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
