### PR TITLE
feat(redshift-workgroup): Users can now run custom SQL directly from the `RedshiftServerlessWorkgroup` construct

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -6726,11 +6726,19 @@ new consumption.RedshiftServerlessWorkgroup(scope: Construct, id: string, props:
 | --- | --- |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.toString">toString</a></code> | Returns a string representation of this construct. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.accessData">accessData</a></code> | Creates an instance of `RedshiftData` to send custom SQLs to the workgroup. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.assignDbRolesToIAMRole">assignDbRolesToIAMRole</a></code> | Assigns Redshift DB roles to IAM role vs the `RedshiftDbRoles` tag. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.catalogTables">catalogTables</a></code> | Creates a new Glue data catalog database with a crawler using JDBC target type to connect to the Redshift Workgroup. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createDatabaseFromShare">createDatabaseFromShare</a></code> | Consume datashare by creating a new database pointing to the share. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createDbRole">createDbRole</a></code> | Creates a new DB role. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createShare">createShare</a></code> | Create a new datashare. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantAccessToShare">grantAccessToShare</a></code> | Create a datashare grant to a namespace if it's in the same account, or to another account. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbAllPrivilegesToRole">grantDbAllPrivilegesToRole</a></code> | Grants both read and write permissions on all the tables in the `schema` to the DB role. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbSchemaToRole">grantDbSchemaToRole</a></code> | Grants access to the schema to the DB role. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantSchemaReadToRole">grantSchemaReadToRole</a></code> | Grants read permission on all the tables in the `schema` to the DB role. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData">ingestData</a></code> | Ingest data from S3 into a Redshift table. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable">mergeToTargetTable</a></code> | Run the `MERGE` query using simplified mode. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.retrieveVersion">retrieveVersion</a></code> | Retrieve DSF package.json version. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.runCustomSQL">runCustomSQL</a></code> | Runs a custom SQL. |
 
 ---
 
@@ -6742,7 +6750,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `accessData` <a name="accessData" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.accessData"></a>
+##### ~~`accessData`~~ <a name="accessData" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.accessData"></a>
 
 ```typescript
 public accessData(id: string, createVpcEndpoint?: boolean, existingInterfaceVPCEndpoint?: IInterfaceVpcEndpoint): RedshiftData
@@ -6771,6 +6779,30 @@ if set to true, create interface VPC endpoint for Redshift Data API.
 - *Type:* aws-cdk-lib.aws_ec2.IInterfaceVpcEndpoint
 
 if `createVpcEndpoint` is false, and if this is populated, then the Lambda function's security group would be added in the existing VPC endpoint's security group.
+
+---
+
+##### `assignDbRolesToIAMRole` <a name="assignDbRolesToIAMRole" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.assignDbRolesToIAMRole"></a>
+
+```typescript
+public assignDbRolesToIAMRole(dbRoles: string[], targetRole: IRole): void
+```
+
+Assigns Redshift DB roles to IAM role vs the `RedshiftDbRoles` tag.
+
+###### `dbRoles`<sup>Required</sup> <a name="dbRoles" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.assignDbRolesToIAMRole.parameter.dbRoles"></a>
+
+- *Type:* string[]
+
+List of Redshift DB roles to assign to IAM role.
+
+---
+
+###### `targetRole`<sup>Required</sup> <a name="targetRole" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.assignDbRolesToIAMRole.parameter.targetRole"></a>
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+
+The IAM role to assign the Redshift DB roles to.
 
 ---
 
@@ -6856,6 +6888,38 @@ The producer cluster namespace.
 The producer account ID.
 
 Required for cross account shares.
+
+---
+
+##### `createDbRole` <a name="createDbRole" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createDbRole"></a>
+
+```typescript
+public createDbRole(id: string, databaseName: string, roleName: string): CustomResource
+```
+
+Creates a new DB role.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createDbRole.parameter.id"></a>
+
+- *Type:* string
+
+The CDK Construct ID.
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createDbRole.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `roleName`<sup>Required</sup> <a name="roleName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.createDbRole.parameter.roleName"></a>
+
+- *Type:* string
+
+The name of the role to create.
 
 ---
 
@@ -6959,6 +7023,258 @@ Either namespace or account Id must be provided.
 
 ---
 
+##### `grantDbAllPrivilegesToRole` <a name="grantDbAllPrivilegesToRole" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbAllPrivilegesToRole"></a>
+
+```typescript
+public grantDbAllPrivilegesToRole(id: string, databaseName: string, schema: string, roleName: string): CustomResource
+```
+
+Grants both read and write permissions on all the tables in the `schema` to the DB role.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbAllPrivilegesToRole.parameter.id"></a>
+
+- *Type:* string
+
+The CDK Construct ID.
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbAllPrivilegesToRole.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `schema`<sup>Required</sup> <a name="schema" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbAllPrivilegesToRole.parameter.schema"></a>
+
+- *Type:* string
+
+The schema where the tables are located in.
+
+---
+
+###### `roleName`<sup>Required</sup> <a name="roleName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbAllPrivilegesToRole.parameter.roleName"></a>
+
+- *Type:* string
+
+The DB role to grant the permissions to.
+
+---
+
+##### `grantDbSchemaToRole` <a name="grantDbSchemaToRole" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbSchemaToRole"></a>
+
+```typescript
+public grantDbSchemaToRole(id: string, databaseName: string, schema: string, roleName: string): CustomResource
+```
+
+Grants access to the schema to the DB role.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbSchemaToRole.parameter.id"></a>
+
+- *Type:* string
+
+The CDK Construct ID.
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbSchemaToRole.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `schema`<sup>Required</sup> <a name="schema" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbSchemaToRole.parameter.schema"></a>
+
+- *Type:* string
+
+The schema where the tables are located in.
+
+---
+
+###### `roleName`<sup>Required</sup> <a name="roleName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantDbSchemaToRole.parameter.roleName"></a>
+
+- *Type:* string
+
+The DB role to grant the permissions to.
+
+---
+
+##### `grantSchemaReadToRole` <a name="grantSchemaReadToRole" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantSchemaReadToRole"></a>
+
+```typescript
+public grantSchemaReadToRole(id: string, databaseName: string, schema: string, roleName: string): CustomResource
+```
+
+Grants read permission on all the tables in the `schema` to the DB role.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantSchemaReadToRole.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantSchemaReadToRole.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `schema`<sup>Required</sup> <a name="schema" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantSchemaReadToRole.parameter.schema"></a>
+
+- *Type:* string
+
+The schema where the tables are located in.
+
+---
+
+###### `roleName`<sup>Required</sup> <a name="roleName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.grantSchemaReadToRole.parameter.roleName"></a>
+
+- *Type:* string
+
+The DB role to grant the permissions to.
+
+---
+
+##### `ingestData` <a name="ingestData" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData"></a>
+
+```typescript
+public ingestData(id: string, databaseName: string, targetTable: string, sourceBucket: IBucket, sourcePrefix: string, ingestAdditionalOptions?: string, role?: IRole): CustomResource
+```
+
+Ingest data from S3 into a Redshift table.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.id"></a>
+
+- *Type:* string
+
+The CDK Construct ID.
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `targetTable`<sup>Required</sup> <a name="targetTable" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.targetTable"></a>
+
+- *Type:* string
+
+The target table to load the data into.
+
+---
+
+###### `sourceBucket`<sup>Required</sup> <a name="sourceBucket" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.sourceBucket"></a>
+
+- *Type:* aws-cdk-lib.aws_s3.IBucket
+
+The bucket where the source data would be coming from.
+
+---
+
+###### `sourcePrefix`<sup>Required</sup> <a name="sourcePrefix" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.sourcePrefix"></a>
+
+- *Type:* string
+
+The location inside the bucket where the data would be ingested from.
+
+---
+
+###### `ingestAdditionalOptions`<sup>Optional</sup> <a name="ingestAdditionalOptions" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.ingestAdditionalOptions"></a>
+
+- *Type:* string
+
+Optional.
+
+Additional options to pass to the `COPY` command. For example, `delimiter '|'` or `ignoreheader 1`
+
+---
+
+###### `role`<sup>Optional</sup> <a name="role" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.ingestData.parameter.role"></a>
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+
+Optional.
+
+The IAM Role to use to access the data in S3. If not provided, it would use the default IAM role configured in the Redshift Namespace
+
+---
+
+##### `mergeToTargetTable` <a name="mergeToTargetTable" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable"></a>
+
+```typescript
+public mergeToTargetTable(id: string, databaseName: string, sourceTable: string, targetTable: string, sourceColumnId?: string, targetColumnId?: string): CustomResource
+```
+
+Run the `MERGE` query using simplified mode.
+
+This command would do an upsert into the target table.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable.parameter.id"></a>
+
+- *Type:* string
+
+The CDK Construct ID.
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `sourceTable`<sup>Required</sup> <a name="sourceTable" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable.parameter.sourceTable"></a>
+
+- *Type:* string
+
+The source table name.
+
+Schema can also be included using the following format: `schemaName.tableName`
+
+---
+
+###### `targetTable`<sup>Required</sup> <a name="targetTable" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable.parameter.targetTable"></a>
+
+- *Type:* string
+
+The target table name.
+
+Schema can also be included using the following format: `schemaName.tableName`
+
+---
+
+###### `sourceColumnId`<sup>Optional</sup> <a name="sourceColumnId" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable.parameter.sourceColumnId"></a>
+
+- *Type:* string
+
+The column in the source table that's used to determine whether the rows in the `sourceTable` can be matched with rows in the `targetTable`.
+
+Default is `id`
+
+---
+
+###### `targetColumnId`<sup>Optional</sup> <a name="targetColumnId" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.mergeToTargetTable.parameter.targetColumnId"></a>
+
+- *Type:* string
+
+The column in the target table that's used to determine whether the rows in the `sourceTable` can be matched with rows in the `targetTable`.
+
+Default is `id`
+
+---
+
 ##### `retrieveVersion` <a name="retrieveVersion" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.retrieveVersion"></a>
 
 ```typescript
@@ -6966,6 +7282,50 @@ public retrieveVersion(): any
 ```
 
 Retrieve DSF package.json version.
+
+##### `runCustomSQL` <a name="runCustomSQL" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.runCustomSQL"></a>
+
+```typescript
+public runCustomSQL(id: string, databaseName: string, sql: string, deleteSql?: string): CustomResource
+```
+
+Runs a custom SQL.
+
+Once the custom resource finishes execution, the attribute `Data` contains an attribute `execId` which contains the Redshift Data API execution ID. You can then use this to retrieve execution results via the `GetStatementResult` API.
+
+###### `id`<sup>Required</sup> <a name="id" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.runCustomSQL.parameter.id"></a>
+
+- *Type:* string
+
+The CDK Construct ID.
+
+---
+
+###### `databaseName`<sup>Required</sup> <a name="databaseName" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.runCustomSQL.parameter.databaseName"></a>
+
+- *Type:* string
+
+The name of the database to run this command.
+
+---
+
+###### `sql`<sup>Required</sup> <a name="sql" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.runCustomSQL.parameter.sql"></a>
+
+- *Type:* string
+
+The sql to run.
+
+---
+
+###### `deleteSql`<sup>Optional</sup> <a name="deleteSql" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroup.runCustomSQL.parameter.deleteSql"></a>
+
+- *Type:* string
+
+Optional.
+
+The sql to run when this resource gets deleted
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 

--- a/framework/src/consumption/examples/redshift-data-sharing-cross-account.lit.ts
+++ b/framework/src/consumption/examples/redshift-data-sharing-cross-account.lit.ts
@@ -20,8 +20,7 @@ class ExampleRedshiftDataSharingCrossAccountAStack extends Stack {
     
     const shareName = 'testshare';
 
-    const producerDataAccess = producerWorkgroup.accessData('ProducerDataAccess');
-    const createCustomersTable = producerDataAccess.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
+    const createCustomersTable = producerWorkgroup.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
 
     const newShare = producerWorkgroup.createShare('producer-share', dbName, shareName, 'public', ['public.customers']);
     newShare.newShareCustomResource.node.addDependency(createCustomersTable);

--- a/framework/src/consumption/examples/redshift-data-sharing-same-account.lit.ts
+++ b/framework/src/consumption/examples/redshift-data-sharing-same-account.lit.ts
@@ -30,8 +30,7 @@ class ExampleRedshiftDataSharingSameAccountStack extends Stack {
     
     const shareName = 'testshare';
 
-    const producerDataAccess = producerWorkgroup.accessData('ProducerDataAccess');
-    const createCustomersTable = producerDataAccess.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
+    const createCustomersTable = producerWorkgroup.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
 
     const newShare = producerWorkgroup.createShare('producer-share', dbName, shareName, 'public', ['public.customers']);
     newShare.newShareCustomResource.node.addDependency(createCustomersTable);

--- a/framework/src/consumption/examples/redshift-serverless-workgroup-bootstrap.lit.ts
+++ b/framework/src/consumption/examples/redshift-serverless-workgroup-bootstrap.lit.ts
@@ -29,11 +29,8 @@ class ExampleRedshiftServerlessWorkgroupBootstrapStack extends Stack {
       namespace: namespace,
     })
 
-    // Initialize the Redshift Data API
-    const dataAccess = workgroup.accessData('DataApi', true)
-
     // Run a custom SQL to create a customer table
-    const createTable = dataAccess.runCustomSQL('CreateCustomerTable', "defaultdb", 
+    const createTable = workgroup.runCustomSQL('CreateCustomerTable', "defaultdb", 
       `
       CREATE TABLE customer(
         customer_id varchar(50), 
@@ -48,16 +45,16 @@ class ExampleRedshiftServerlessWorkgroupBootstrapStack extends Stack {
     );
 
     // Run a COPY command to load data into the customer table
-    const ingestion = dataAccess.ingestData('ExampleCopy', "defaultdb", "customer", bucket, "data-products/customer/", "csv ignoreheader 1");
+    const ingestion = workgroup.ingestData('ExampleCopy', "defaultdb", "customer", bucket, "data-products/customer/", "csv ignoreheader 1");
 
     // Add dependencies between Redshift Data API commands because CDK cannot infer them
     ingestion.node.addDependency(createTable);
 
     // Create an engineering role in the defaultdb
-    const dbRole = dataAccess.createDbRole('EngineeringRole', 'defaultdb', 'engineering');
+    const dbRole = workgroup.createDbRole('EngineeringRole', 'defaultdb', 'engineering');
 
     // Grant the engineering role full access to the public schema in the defaultdb
-    const dbSchema = dataAccess.grantDbSchemaToRole('EngineeringGrant', 'defaultdb', 'public', 'engineering');
+    const dbSchema = workgroup.grantDbSchemaToRole('EngineeringGrant', 'defaultdb', 'public', 'engineering');
 
     // Enforce dependencies
     dbSchema.node.addDependency(dbRole);

--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { CustomResource, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Connections, IConnectable, IInterfaceVpcEndpoint, ISecurityGroup, IVpc, Port, SecurityGroup, SelectedSubnets } from 'aws-cdk-lib/aws-ec2';
 import { CfnConnection } from 'aws-cdk-lib/aws-glue';
+import { IRole } from 'aws-cdk-lib/aws-iam';
 import { CfnWorkgroup } from 'aws-cdk-lib/aws-redshiftserverless';
+import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { RedshiftServerlessNamespace } from './redshift-serverless-namespace';
 import { RedshiftServerlessWorkgroupProps } from './redshift-serverless-workgroup-props';
@@ -250,9 +252,9 @@ export class RedshiftServerlessWorkgroup extends TrackedConstruct implements ICo
    * @param existingInterfaceVPCEndpoint if `createVpcEndpoint` is false, and if this is populated,
    * then the Lambda function's security group would be added in the existing VPC endpoint's security group.
    * @returns `RedshiftData`
+   * @deprecated Use the convenience methods directly from the `RedshiftServerlessWorkgroup` construct.
    */
   public accessData(id: string, createVpcEndpoint?: boolean, existingInterfaceVPCEndpoint?: IInterfaceVpcEndpoint): RedshiftData {
-
     if (!this.redshiftData) {
       this.redshiftData = new RedshiftData(this, id, {
         secret: this.namespace.adminSecret,
@@ -269,6 +271,107 @@ export class RedshiftServerlessWorkgroup extends TrackedConstruct implements ICo
     }
 
     return this.redshiftData;
+  }
+
+  /**
+   * Runs a custom SQL. Once the custom resource finishes execution, the attribute `Data` contains an attribute `execId` which contains the Redshift Data API execution ID. You can then use this to retrieve execution results via the `GetStatementResult` API.
+   * @param id The CDK Construct ID
+   * @param databaseName The name of the database to run this command
+   * @param sql The sql to run
+   * @param deleteSql Optional. The sql to run when this resource gets deleted
+   * @returns `CustomResource`
+   */
+  public runCustomSQL(id: string, databaseName: string, sql: string, deleteSql?: string): CustomResource {
+    return this.accessData(`${id}AccessData`, true).runCustomSQL(id, databaseName, sql, deleteSql);
+  }
+
+  /**
+   * Creates a new DB role
+   * @param id The CDK Construct ID
+   * @param databaseName The name of the database to run this command
+   * @param roleName The name of the role to create
+   * @returns `CustomResource`
+   */
+  public createDbRole(id: string, databaseName: string, roleName: string): CustomResource {
+    return this.accessData(`${id}AccessData`, true).createDbRole(id, databaseName, roleName);
+  }
+
+  /**
+   * Grants access to the schema to the DB role
+   * @param id The CDK Construct ID
+   * @param databaseName The name of the database to run this command
+   * @param schema The schema where the tables are located in
+   * @param roleName The DB role to grant the permissions to
+   * @returns `CustomResource`
+   */
+  public grantDbSchemaToRole(id: string, databaseName: string, schema: string, roleName: string): CustomResource {
+    return this.accessData(`${id}AccessData`).grantDbSchemaToRole(id, databaseName, schema, roleName);
+  }
+
+  /**
+   * Grants read permission on all the tables in the `schema` to the DB role
+   * @param databaseName The name of the database to run this command
+   * @param schema The schema where the tables are located in
+   * @param roleName The DB role to grant the permissions to
+   * @returns `CustomResource`
+   */
+  public grantSchemaReadToRole(id: string, databaseName: string, schema: string, roleName: string): CustomResource {
+    return this.accessData(`${id}AccessData`).grantSchemaReadToRole(id, databaseName, schema, roleName);
+  }
+
+  /**
+   * Grants both read and write permissions on all the tables in the `schema` to the DB role
+   * @param id The CDK Construct ID
+   * @param databaseName The name of the database to run this command
+   * @param schema The schema where the tables are located in
+   * @param roleName The DB role to grant the permissions to
+   * @returns `CustomResource`
+   */
+  public grantDbAllPrivilegesToRole(id: string, databaseName: string, schema: string, roleName: string): CustomResource {
+    return this.accessData(`${id}AccessData`).grantDbAllPrivilegesToRole(id, databaseName, schema, roleName);
+  }
+
+  /**
+   * Assigns Redshift DB roles to IAM role vs the `RedshiftDbRoles` tag
+   * @param dbRoles List of Redshift DB roles to assign to IAM role
+   * @param targetRole The IAM role to assign the Redshift DB roles to
+   */
+  public assignDbRolesToIAMRole(dbRoles: string[], targetRole: IRole) {
+    const idHash = Utils.generateHash(JSON.stringify(dbRoles) + ' ' + JSON.stringify(targetRole));
+    this.accessData(`${idHash}AccessData`).assignDbRolesToIAMRole(dbRoles, targetRole);
+  }
+
+  /**
+   * Ingest data from S3 into a Redshift table
+   * @param id The CDK Construct ID
+   * @param databaseName The name of the database to run this command
+   * @param targetTable The target table to load the data into
+   * @param sourceBucket The bucket where the source data would be coming from
+   * @param sourcePrefix The location inside the bucket where the data would be ingested from
+   * @param ingestAdditionalOptions Optional. Additional options to pass to the `COPY` command. For example, `delimiter '|'` or `ignoreheader 1`
+   * @param role Optional. The IAM Role to use to access the data in S3. If not provided, it would use the default IAM role configured in the Redshift Namespace
+   * @returns
+   */
+  public ingestData(id: string, databaseName: string, targetTable: string, sourceBucket: IBucket, sourcePrefix: string,
+    ingestAdditionalOptions?: string, role?: IRole): CustomResource {
+    return this.accessData(`${id}AccessData`).ingestData(id, databaseName, targetTable, sourceBucket
+      , sourcePrefix, ingestAdditionalOptions, role);
+  }
+
+  /**
+   * Run the `MERGE` query using simplified mode. This command would do an upsert into the target table.
+   * @param id The CDK Construct ID
+   * @param databaseName The name of the database to run this command
+   * @param sourceTable The source table name. Schema can also be included using the following format: `schemaName.tableName`
+   * @param targetTable The target table name. Schema can also be included using the following format: `schemaName.tableName`
+   * @param sourceColumnId The column in the source table that's used to determine whether the rows in the `sourceTable` can be matched with rows in the `targetTable`. Default is `id`
+   * @param targetColumnId The column in the target table that's used to determine whether the rows in the `sourceTable` can be matched with rows in the `targetTable`. Default is `id`
+   * @returns `CustomResource`
+   */
+  public mergeToTargetTable(id: string, databaseName: string, sourceTable: string, targetTable: string, sourceColumnId?: string
+    , targetColumnId?: string): CustomResource {
+    return this.accessData(`${id}AccessData`).mergeToTargetTable(id, databaseName, sourceTable
+      , targetTable, sourceColumnId, targetColumnId);
   }
 
   /**

--- a/framework/test/e2e/redshift-serverless.e2e.test.ts
+++ b/framework/test/e2e/redshift-serverless.e2e.test.ts
@@ -75,11 +75,10 @@ const workgroup = new RedshiftServerlessWorkgroup(stack, 'RedshiftWorkgroup', {
   removalPolicy: RemovalPolicy.DESTROY,
 });
 
-const dataApi = workgroup.accessData('DataApi', true);
-const schema = dataApi.runCustomSQL('TestCustom', 'defaultdb', 'create schema testschema');
-const dbRole = dataApi.createDbRole('EngineeringRole', 'defaultdb', 'engineering');
-const dbSchema = dataApi.grantDbSchemaToRole('EngineeringGrant', 'defaultdb', 'testschema', 'engineering');
-const readSchema = dataApi.grantSchemaReadToRole('EngineeringGrantRead', 'defaultdb', 'public', 'engineering');
+const schema = workgroup.runCustomSQL('TestCustom', 'defaultdb', 'create schema testschema');
+const dbRole = workgroup.createDbRole('EngineeringRole', 'defaultdb', 'engineering');
+const dbSchema = workgroup.grantDbSchemaToRole('EngineeringGrant', 'defaultdb', 'testschema', 'engineering');
+const readSchema = workgroup.grantSchemaReadToRole('EngineeringGrantRead', 'defaultdb', 'public', 'engineering');
 
 dbSchema.node.addDependency(dbRole);
 dbSchema.node.addDependency(schema);

--- a/framework/test/unit/consumption/redshift-serverless-workgroup.test.ts
+++ b/framework/test/unit/consumption/redshift-serverless-workgroup.test.ts
@@ -25,11 +25,10 @@ describe('With default configuration, the construct should', () => {
     namespace,
   });
 
-  workgroup.accessData('DataApi');
+  workgroup.runCustomSQL('DataApiCheck', 'defaultdb', 'select 1');
   workgroup.catalogTables('CatalogTables', 'default_test_db');
 
   const template = Template.fromStack(stack);
-  // console.log(JSON.stringify(template.toJSON(), null, 2));
 
   test('Create a DataVpc with corresponding resources', () => {
     template.hasResourceProperties('AWS::KMS::Key', {
@@ -147,12 +146,8 @@ describe('With default configuration, the construct should', () => {
   });
 
   test('create the Redshift Redshift Data API custom resource', () => {
-    template.hasResourceProperties('AWS::IAM::Role', {
-      ManagedPolicyArns: [
-        {
-          Ref: Match.stringLikeRegexp('DefaultWorkgroupDataApiCrProviderVpcPolicy.*'),
-        },
-      ],
+    template.hasResourceProperties('Custom::RedshiftDataSql', {
+      sql: Match.exact('select 1'),
     });
   });
 
@@ -251,7 +246,7 @@ describe('With custom configuration and global removal policy unset, the constru
     extraSecurityGroups,
   });
 
-  workgroup.accessData('DataApi', true);
+  // workgroup.accessData('DataApi', true);
 
   workgroup.catalogTables('DefaultDbCatalog', 'redshift_default_db', 'defaultdb/public/test%');
 
@@ -281,16 +276,6 @@ describe('With custom configuration and global removal policy unset, the constru
       },
       UpdateReplacePolicy: 'Retain',
       DeletionPolicy: 'Retain',
-    });
-  });
-
-  test('Has data access custom resource', () => {
-    template.hasResourceProperties('AWS::Lambda::Function', {
-      Handler: Match.exact('index.onEventHandler'),
-    });
-
-    template.hasResourceProperties('AWS::Lambda::Function', {
-      Handler: Match.exact('index.isCompleteHandler'),
     });
   });
 
@@ -377,7 +362,6 @@ describe('With custom configuration and removal policy set to DESTROY, the const
     removalPolicy: RemovalPolicy.DESTROY,
   });
 
-  workgroup.accessData('DataApi');
   workgroup.catalogTables('CatalogTables', 'default_test_db');
 
   const template = Template.fromStack(stack);

--- a/framework/test/unit/nag/consumption/nag-redshift-serverless.test.ts
+++ b/framework/test/unit/nag/consumption/nag-redshift-serverless.test.ts
@@ -49,7 +49,7 @@ const workgroup = new RedshiftServerlessWorkgroup(stack, 'RedshiftWorkgroup', {
   extraSecurityGroups,
 });
 
-workgroup.accessData('DataApi', true);
+workgroup.runCustomSQL('DataApiCheck', 'defaultdb', 'select 1');
 
 workgroup.catalogTables('RedshiftCatalog', 'redshift_default_db', 'defaultdb/public/test%');
 
@@ -82,7 +82,7 @@ NagSuppressions.addResourceSuppressionsByPath(stack,
 );
 
 NagSuppressions.addResourceSuppressionsByPath(stack, [
-  'Stack/RedshiftWorkgroup/DataApi',
+  'Stack/RedshiftWorkgroup/DataApiCheckAccessData',
   'Stack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a',
   'Stack/DefaultNamespace/Provider/CustomResourceProvider',
   'Stack/Vpc/Resource',

--- a/website/docs/constructs/library/generated/_consumption-redshift-data-sharing.mdx
+++ b/website/docs/constructs/library/generated/_consumption-redshift-data-sharing.mdx
@@ -47,8 +47,7 @@ class ExampleRedshiftDataSharingSameAccountStack extends Stack {
 
     const shareName = 'testshare';
 
-    const producerDataAccess = producerWorkgroup.accessData('ProducerDataAccess');
-    const createCustomersTable = producerDataAccess.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
+    const createCustomersTable = producerWorkgroup.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
 
     const newShare = producerWorkgroup.createShare('producer-share', dbName, shareName, 'public', ['public.customers']);
     newShare.newShareCustomResource.node.addDependency(createCustomersTable);
@@ -99,8 +98,7 @@ class ExampleRedshiftDataSharingSameAccountStack(Stack):
 
         share_name = "testshare"
 
-        producer_data_access = producer_workgroup.access_data("ProducerDataAccess")
-        create_customers_table = producer_data_access.run_custom_sQL("CreateCustomerTable", db_name, "create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)", "drop table public.customers")
+        create_customers_table = producer_workgroup.run_custom_sQL("CreateCustomerTable", db_name, "create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)", "drop table public.customers")
 
         new_share = producer_workgroup.create_share("producer-share", db_name, share_name, "public", ["public.customers"])
         new_share.new_share_custom_resource.node.add_dependency(create_customers_table)
@@ -141,8 +139,7 @@ class ExampleRedshiftDataSharingCrossAccountAStack extends Stack {
 
     const shareName = 'testshare';
 
-    const producerDataAccess = producerWorkgroup.accessData('ProducerDataAccess');
-    const createCustomersTable = producerDataAccess.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
+    const createCustomersTable = producerWorkgroup.runCustomSQL('CreateCustomerTable', dbName, 'create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)', 'drop table public.customers');
 
     const newShare = producerWorkgroup.createShare('producer-share', dbName, shareName, 'public', ['public.customers']);
     newShare.newShareCustomResource.node.addDependency(createCustomersTable);
@@ -200,8 +197,7 @@ class ExampleRedshiftDataSharingCrossAccountAStack(Stack):
 
         share_name = "testshare"
 
-        producer_data_access = producer_workgroup.access_data("ProducerDataAccess")
-        create_customers_table = producer_data_access.run_custom_sQL("CreateCustomerTable", db_name, "create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)", "drop table public.customers")
+        create_customers_table = producer_workgroup.run_custom_sQL("CreateCustomerTable", db_name, "create table public.customers (id varchar(100) not null, first_name varchar(50) not null, last_name varchar(50) not null, email varchar(100) not null)", "drop table public.customers")
 
         new_share = producer_workgroup.create_share("producer-share", db_name, share_name, "public", ["public.customers"])
         new_share.new_share_custom_resource.node.add_dependency(create_customers_table)

--- a/website/docs/constructs/library/generated/_consumption-redshift-serverless-workgroup.mdx
+++ b/website/docs/constructs/library/generated/_consumption-redshift-serverless-workgroup.mdx
@@ -77,11 +77,8 @@ The `RedshiftData` construct provides the following helpers for bootstrapping Re
       namespace: namespace,
     })
 
-    // Initialize the Redshift Data API
-    const dataAccess = workgroup.accessData('DataApi', true)
-
     // Run a custom SQL to create a customer table
-    const createTable = dataAccess.runCustomSQL('CreateCustomerTable', "defaultdb",
+    const createTable = workgroup.runCustomSQL('CreateCustomerTable', "defaultdb",
       `
       CREATE TABLE customer(
         customer_id varchar(50),
@@ -96,16 +93,16 @@ The `RedshiftData` construct provides the following helpers for bootstrapping Re
     );
 
     // Run a COPY command to load data into the customer table
-    const ingestion = dataAccess.ingestData('ExampleCopy', "defaultdb", "customer", bucket, "data-products/customer/", "csv ignoreheader 1");
+    const ingestion = workgroup.ingestData('ExampleCopy', "defaultdb", "customer", bucket, "data-products/customer/", "csv ignoreheader 1");
 
     // Add dependencies between Redshift Data API commands because CDK cannot infer them
     ingestion.node.addDependency(createTable);
 
     // Create an engineering role in the defaultdb
-    const dbRole = dataAccess.createDbRole('EngineeringRole', 'defaultdb', 'engineering');
+    const dbRole = workgroup.createDbRole('EngineeringRole', 'defaultdb', 'engineering');
 
     // Grant the engineering role full access to the public schema in the defaultdb
-    const dbSchema = dataAccess.grantDbSchemaToRole('EngineeringGrant', 'defaultdb', 'public', 'engineering');
+    const dbSchema = workgroup.grantDbSchemaToRole('EngineeringGrant', 'defaultdb', 'public', 'engineering');
 
     // Enforce dependencies
     dbSchema.node.addDependency(dbRole);
@@ -122,11 +119,8 @@ workgroup = dsf.consumption.RedshiftServerlessWorkgroup(self, "DefaultRedshiftSe
     namespace=namespace
 )
 
-# Initialize the Redshift Data API
-data_access = workgroup.access_data("DataApi", True)
-
 # Run a custom SQL to create a customer table
-create_table = data_access.run_custom_sQL("CreateCustomerTable", "defaultdb", """
+create_table = workgroup.run_custom_sQL("CreateCustomerTable", "defaultdb", """
           CREATE TABLE customer(
             customer_id varchar(50),
             salutation varchar(5),
@@ -138,16 +132,16 @@ create_table = data_access.run_custom_sQL("CreateCustomerTable", "defaultdb", ""
           """, "drop table customer")
 
 # Run a COPY command to load data into the customer table
-ingestion = data_access.ingest_data("ExampleCopy", "defaultdb", "customer", bucket, "data-products/customer/", "csv ignoreheader 1")
+ingestion = workgroup.ingest_data("ExampleCopy", "defaultdb", "customer", bucket, "data-products/customer/", "csv ignoreheader 1")
 
 # Add dependencies between Redshift Data API commands because CDK cannot infer them
 ingestion.node.add_dependency(create_table)
 
 # Create an engineering role in the defaultdb
-db_role = data_access.create_db_role("EngineeringRole", "defaultdb", "engineering")
+db_role = workgroup.create_db_role("EngineeringRole", "defaultdb", "engineering")
 
 # Grant the engineering role full access to the public schema in the defaultdb
-db_schema = data_access.grant_db_schema_to_role("EngineeringGrant", "defaultdb", "public", "engineering")
+db_schema = workgroup.grant_db_schema_to_role("EngineeringGrant", "defaultdb", "public", "engineering")
 
 # Enforce dependencies
 db_schema.node.add_dependency(db_role)


### PR DESCRIPTION
## Description of changes:

Streamlined Redshift Data API. Users can now run custom SQL directly from the `RedshiftServerlessWorkgroup`

**Checklist**

* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
