### PR TITLE
fix: Missing import for cdk construct in documentation

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -88,18 +88,19 @@ In `lib/dsf-example-stack.ts`
   import * as dsf from '@cdklabs/aws-data-solutions-framework';
   import { Key } from 'aws-cdk-lib/aws-kms';
   import { Policy, PolicyStatement} from 'aws-cdk-lib/aws-iam';
+  import { Construct } from 'constructs';
 
   export class DsfExampleStack extends cdk.Stack {
-    constructor(scope: cdk.Construt, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
       super(scope, id, props);
-
-    const storage = new dsf.storage.AnalyticsBucket(this, 'AnalyticsBucket', {
-      encryptionKey: new Key(this, 'DataKey', {
+      
+      const storage = new dsf.storage.AnalyticsBucket(this, 'AnalyticsBucket', {
+        encryptionKey: new Key(this, 'DataKey', {
           enableKeyRotation: true,
           removalPolicy: cdk.RemovalPolicy.DESTROY
         }),
-    });
-  }
+      });
+    }
   ```
   
   ```mdx-code-block


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

fix: Missing import for cdk construct in documentation

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
