### PR TITLE
fix: Redshift JDBC Crawler is now able to read credentials stored in Secrets Manager

### DIFF
--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
@@ -136,7 +136,7 @@ export class RedshiftServerlessWorkgroup extends TrackedConstruct implements ICo
       name: catalogDbName,
       glueConnectionName: `glue-conn-${this.cfnResource.workgroupName}`,
       jdbcSecret: this.namespace.adminSecret,
-      jdbcSecretKMSKey: this.namespace.dataKey,
+      jdbcSecretKMSKey: this.namespace.adminSecretKey,
       jdbcPath: pathToCrawl,
       removalPolicy: this.removalPolicy,
     });


### PR DESCRIPTION
## Description of changes: JDBC crawler is now configured with the right KMS key to access the credentials stored in Secrets Manager

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
