### PR TITLE
fix: Adding missing IAM policy to be able to execute updates on MSK topics

### DIFF
--- a/framework/src/streaming/lib/msk/msk-helpers.ts
+++ b/framework/src/streaming/lib/msk/msk-helpers.ts
@@ -78,6 +78,7 @@ export function mskIamCrudProviderSetup(
         'kafka-cluster:AlterTopic',
         'kafka-cluster:DeleteTopic',
         'kafka-cluster:DescribeTopicDynamicConfiguration',
+        'kafka-cluster:AlterTopicDynamicConfiguration',
       ],
       resources: [
         `arn:${partition}:kafka:${region}:${account}:topic/${clusterNameUuid}/*`,

--- a/framework/test/unit/streaming/kafka-api.test.ts
+++ b/framework/test/unit/streaming/kafka-api.test.ts
@@ -182,6 +182,7 @@ describe('Using default KafkaApi configuration with MSK provisioned and IAM and 
               'kafka-cluster:AlterTopic',
               'kafka-cluster:DeleteTopic',
               'kafka-cluster:DescribeTopicDynamicConfiguration',
+              'kafka-cluster:AlterTopicDynamicConfiguration',
             ],
             Effect: 'Allow',
             Resource: {


### PR DESCRIPTION
#676 

## Description of changes:

Adding missing IAM policy to be able to update properties on MSK topics

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
