### PR TITLE
chore(e2e): Change the source bucket used in S3DataCopy e2e test

### DIFF
--- a/framework/test/e2e/s3-data-copy.e2e.test.ts
+++ b/framework/test/e2e/s3-data-copy.e2e.test.ts
@@ -19,7 +19,7 @@ const { stack } = testStack;
 // Set the context value for global data removal policy
 stack.node.setContext('@data-solutions-framework-on-aws/removeDataOnDestroy', true);
 
-const sourceBucket = Bucket.fromBucketName(stack, 'SourceBucket', 'nyc-tlc');
+const sourceBucket = Bucket.fromBucketName(stack, 'SourceBucket', 'e2e-test-bucket-dsf');
 const bucketName = `test-${stack.region}-${stack.account}-${Utils.generateUniqueHash(stack, 'TargetBucket')}`;
 
 const targetBucket = new Bucket(stack, 'TargetBucket', {
@@ -32,8 +32,7 @@ const vpc = new Vpc(stack, 'Vpc');
 
 new S3DataCopy(stack, 'S3DataCopy', {
   sourceBucket,
-  sourceBucketPrefix: 'trip data/',
-  sourceBucketRegion: 'us-east-1',
+  sourceBucketRegion: 'eu-west-1',
   targetBucket,
   removalPolicy: RemovalPolicy.DESTROY,
   vpc,

--- a/framework/test/unit/streaming/msk-provisioned.test.ts
+++ b/framework/test/unit/streaming/msk-provisioned.test.ts
@@ -249,7 +249,7 @@ describe('Create an MSK Provisioned cluster with mTlS auth, provided vpc and add
       ExecuteOnHandlerChange: true,
       InvocationType: 'RequestResponse',
       ServiceToken: { 'Fn::GetAtt': ['AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91', 'Arn'] },
-      HandlerArn: { Ref: 'clusterUpdateZookeeperSgCurrentVersion6BC0411Dd3f8c0b3f35baf66398142df7e12bedd' },
+      HandlerArn: { Ref: 'clusterUpdateZookeeperSgCurrentVersion6BC0411Da09a8dad02386cf9ab1285840130679b' },
     });
   });
 
@@ -322,7 +322,7 @@ describe('Create an MSK Provisioned cluster with mTlS auth, provided vpc and add
     template.hasResourceProperties('Custom::Trigger', {
       ExecuteOnHandlerChange: true,
       InvocationType: 'RequestResponse',
-      HandlerArn: { Ref: 'clusterUpdateZookeeperSgCurrentVersion6BC0411Dd3f8c0b3f35baf66398142df7e12bedd' },
+      HandlerArn: { Ref: 'clusterUpdateZookeeperSgCurrentVersion6BC0411Da09a8dad02386cf9ab1285840130679b' },
     });
   });
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Currently the S3DataCopy e2e test is broken because the source bucket is no longer public. This PR change the source bucket used in S3DataCopy e2e test. This bucket is owned by account that runs e2e.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
