### PR TITLE
chore: change source bucket for Spark Data Lake example

### DIFF
--- a/examples/spark-data-lake/infra/stacks/application_stack.py
+++ b/examples/spark-data-lake/infra/stacks/application_stack.py
@@ -37,14 +37,14 @@ class ApplicationStack(Stack):
         )
 
         # Import the S3 bucket used as the Spark job source
-        source_bucket = s3.Bucket.from_bucket_name(self, 'SourceBucket', 'nyc-tlc')
+        source_bucket = s3.Bucket.from_bucket_name(self, 'SourceBucket', 'redshift-demos')
 
         # Copy the Yellow taxi data in the silver bucket of the data lake
         dsf.utils.S3DataCopy(
             self,
             "YellowDataCopy",
             source_bucket=source_bucket,
-            source_bucket_prefix="trip data/yellow_tripdata_2019",
+            source_bucket_prefix="data/NY-Pub/year=2016/month=1/type=yellow",
             source_bucket_region="us-east-1",
             target_bucket= storage.silver_bucket,
             target_bucket_prefix="yellow-trip-data/",
@@ -56,7 +56,7 @@ class ApplicationStack(Stack):
             self,
             "GreenDataCopy",
             source_bucket=source_bucket,
-            source_bucket_prefix="trip data/green_tripdata_2019",
+            source_bucket_prefix="data/NY-Pub/year=2016/month=1/type=green",
             source_bucket_region="us-east-1",
             target_bucket= storage.silver_bucket,
             target_bucket_prefix="green-trip-data/",


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

The current source bucket of the Spark Data Lake example is not public anymore, this PR change it to a bucket owned by AWS

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
