### PR TITLE
feat: Configure advanced controls for Redshift Serverless Workgroup

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -15489,6 +15489,7 @@ const redshiftServerlessWorkgroupProps: consumption.RedshiftServerlessWorkgroupP
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.name">name</a></code> | <code>string</code> | The name of the Redshift Serverless Workgroup. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.namespace">namespace</a></code> | <code>@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessNamespace</code> | The Redshift Serverless Namespace associated with the Workgroup. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.baseCapacity">baseCapacity</a></code> | <code>number</code> | The base capacity of the Redshift Serverless Workgroup in RPU. |
+| <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.configParameters">configParameters</a></code> | <code>aws-cdk-lib.aws_redshiftserverless.CfnWorkgroup.ConfigParameterProperty[]</code> | Additional parameters to set for advanced control over the Redshift Workgroup. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.extraSecurityGroups">extraSecurityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.SecurityGroup[]</code> | The extra EC2 Security Groups to associate with the Redshift Serverless Workgroup (in addition to the primary Security Group). |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.port">port</a></code> | <code>number</code> | The custom port to use when connecting to workgroup. |
 | <code><a href="#@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | The removal policy when deleting the CDK resource. |
@@ -15531,6 +15532,22 @@ public readonly baseCapacity: number;
 - *Default:* 128 RPU
 
 The base capacity of the Redshift Serverless Workgroup in RPU.
+
+---
+
+##### `configParameters`<sup>Optional</sup> <a name="configParameters" id="@cdklabs/aws-data-solutions-framework.consumption.RedshiftServerlessWorkgroupProps.property.configParameters"></a>
+
+```typescript
+public readonly configParameters: ConfigParameterProperty[];
+```
+
+- *Type:* aws-cdk-lib.aws_redshiftserverless.CfnWorkgroup.ConfigParameterProperty[]
+- *Default:* `require_ssl` parameter is set to true.
+
+Additional parameters to set for advanced control over the Redshift Workgroup.
+
+See {@link https://docs.aws.amazon.com/redshift-serverless/latest/APIReference/API_CreateWorkgroup.html#redshiftserverless-CreateWorkgroup-request-configParameters}
+for more information on what parameters can be set.
 
 ---
 

--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup-props.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup-props.ts
@@ -3,6 +3,7 @@
 
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { SecurityGroup, SubnetSelection, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { CfnWorkgroup } from 'aws-cdk-lib/aws-redshiftserverless';
 import { RedshiftServerlessNamespace } from './redshift-serverless-namespace';
 
 /**
@@ -55,4 +56,12 @@ export interface RedshiftServerlessWorkgroupProps {
    * @default - 5439
    */
   readonly port?: number;
+
+  /**
+   * Additional parameters to set for advanced control over the Redshift Workgroup.
+   * See {@link https://docs.aws.amazon.com/redshift-serverless/latest/APIReference/API_CreateWorkgroup.html#redshiftserverless-CreateWorkgroup-request-configParameters}
+   * for more information on what parameters can be set.
+   * @default - `require_ssl` parameter is set to true.
+   */
+  readonly configParameters?: CfnWorkgroup.ConfigParameterProperty[];
 }

--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
@@ -104,6 +104,17 @@ export class RedshiftServerlessWorkgroup extends TrackedConstruct implements ICo
     this.connections = initSecurityGroupDetails.primaryConnections;
     this.port = props.port || RedshiftServerlessWorkgroup.DEFAULT_PORT;
 
+    let configParameters: CfnWorkgroup.ConfigParameterProperty[] = [
+      {
+        parameterKey: 'require_ssl',
+        parameterValue: 'true',
+      },
+    ];
+
+    if (props.configParameters) {
+      configParameters = props.configParameters.concat(configParameters);
+    }
+
     this.cfnResource = new CfnWorkgroup(this, 'Workgroup', {
       workgroupName: `${props.name}${Utils.generateUniqueHash(this, id)}`,
       baseCapacity: props.baseCapacity,
@@ -113,6 +124,7 @@ export class RedshiftServerlessWorkgroup extends TrackedConstruct implements ICo
       publiclyAccessible: false,
       subnetIds: this.selectedSubnets.subnetIds,
       securityGroupIds: initSecurityGroupDetails.securityGroupIds,
+      configParameters,
     });
 
     this.cfnResource.applyRemovalPolicy(this.removalPolicy);

--- a/framework/test/unit/consumption/redshift-serverless-workgroup.test.ts
+++ b/framework/test/unit/consumption/redshift-serverless-workgroup.test.ts
@@ -109,6 +109,12 @@ describe('With default configuration, the construct should', () => {
         { Ref: Match.stringLikeRegexp('^DefaultWorkgroupDefaultVpcPrivateSubnet1.+') },
         { Ref: Match.stringLikeRegexp('^DefaultWorkgroupDefaultVpcPrivateSubnet2.+') },
       ]),
+      ConfigParameters: Match.arrayEquals([
+        {
+          ParameterKey: Match.exact('require_ssl'),
+          ParameterValue: Match.exact('true'),
+        },
+      ]),
       SecurityGroupIds: Match.arrayEquals([
         { 'Fn::GetAtt': [Match.stringLikeRegexp('^DefaultWorkgroupDefaultSecurityGroup.+'), 'GroupId'] },
       ]),


### PR DESCRIPTION
## Description of changes:
Added ability to add ConfigParameters when creating Redshift Serverless Workgroup.
require_ssl is set to true by default
Updated test

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
