### PR TITLE
fix: add missing deps and code connection for git repo

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -9033,6 +9033,7 @@ A CICD Pipeline to test and deploy a Spark application on Amazon EMR in cross-ac
 
 ```typescript
 import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { CodePipelineSource } from 'aws-cdk-lib/pipelines';
 
 interface MyApplicationStackProps extends cdk.StackProps {
   readonly stage: dsf.utils.CICDStage;
@@ -9058,6 +9059,7 @@ class MyStackFactory implements dsf.utils.ApplicationStackFactory {
 class MyCICDStack extends cdk.Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
+
     new dsf.processing.SparkEmrCICDPipeline(this, 'TestConstruct', {
        sparkApplicationName: 'test',
        applicationStackFactory: new MyStackFactory(),
@@ -9068,8 +9070,11 @@ class MyCICDStack extends cdk.Stack {
        integTestEnv: {
          TEST_BUCKET: 'BucketName',
        },
-    });
-  }
+       source: CodePipelineSource.connection('owner/weekly-job', 'mainline', {
+             connectionArn: 'arn:aws:codeconnections:eu-west-1:123456789012:connection/aEXAMPLE-8aad-4d5d-8878-dfcab0bc441f'
+       }),
+  });
+}
 }
 ```
 

--- a/framework/src/processing/lib/cicd-pipeline/spark-emr-cicd-pipeline.ts
+++ b/framework/src/processing/lib/cicd-pipeline/spark-emr-cicd-pipeline.ts
@@ -26,6 +26,7 @@ import { DEFAULT_SPARK_IMAGE, SparkImage } from '../emr-releases';
  * @exampleMetadata fixture=imports-only
  * @example
  * import { Bucket } from 'aws-cdk-lib/aws-s3';
+ * import { CodePipelineSource } from 'aws-cdk-lib/pipelines';
  *
  * interface MyApplicationStackProps extends cdk.StackProps {
  *   readonly stage: dsf.utils.CICDStage;
@@ -51,6 +52,7 @@ import { DEFAULT_SPARK_IMAGE, SparkImage } from '../emr-releases';
  * class MyCICDStack extends cdk.Stack {
  *   constructor(scope: Construct, id: string) {
  *     super(scope, id);
+ *
  *     new dsf.processing.SparkEmrCICDPipeline(this, 'TestConstruct', {
  *        sparkApplicationName: 'test',
  *        applicationStackFactory: new MyStackFactory(),
@@ -61,8 +63,11 @@ import { DEFAULT_SPARK_IMAGE, SparkImage } from '../emr-releases';
  *        integTestEnv: {
  *          TEST_BUCKET: 'BucketName',
  *        },
- *     });
- *   }
+ *        source: CodePipelineSource.connection('owner/weekly-job', 'mainline', {
+ *              connectionArn: 'arn:aws:codeconnections:eu-west-1:123456789012:connection/aEXAMPLE-8aad-4d5d-8878-dfcab0bc441f'
+ *        }),
+ *   });
+ * }
  * }
  */
 export class SparkEmrCICDPipeline extends TrackedConstruct {


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

The sparkcicd example that is published to construct hub was missing a parameter for the connection to source code repo. This PR add the parameter and the necessary imports.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
