### PR TITLE
ci: fix release github action missing hidden file issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           name: build-artifact
           path: framework/dist
+          include-hidden-files: true
       - name: Backup examples permissions
         working-directory: examples
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

The upload-artifact github action introduced a breaking change in v4, it no longer package hidden files by default that are needed by `projen`. This PR set the `include-hidden-files` to true to include the hidden files that are used by `projen`.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
