### PR TITLE
fix: Ensure RedshiftServerlessNamespace uses adminUsername prop

### DIFF
--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace.ts
@@ -131,7 +131,7 @@ export class RedshiftServerlessNamespace extends TrackedConstruct {
     this.namespaceParameters = {
       namespaceName: this.namespaceName,
       managedAdminPasswordKeyId: this.adminSecretKey.keyId,
-      adminUsername: 'admin',
+      adminUsername: props.adminUsername || 'admin',
       dbName: props.dbName,
       defaultIamRoleArn: props.defaultIAMRole ? props.defaultIAMRole.roleArn : undefined,
       iamRoles: this.roles ? Object.keys(this.roles) : undefined,


### PR DESCRIPTION
## Description of changes:

Currently the [RedshiftServerlessNamespaceProps]https://github.com/awslabs/data-solutions-framework-on-aws/blob/main/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace-props.ts#L56-L60) defines a `adminUsername` property, but the [construct itself ignores it](https://github.com/awslabs/data-solutions-framework-on-aws/blob/main/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-namespace.ts#L134) and only uses a hardcoded default value of `admin`. This PR ensures the value is used when populated.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
