### PR TITLE
chore: fix Spark data lake example by setting the EMR version

### DIFF
--- a/examples/spark-data-lake/infra/stacks/application_stack.py
+++ b/examples/spark-data-lake/infra/stacks/application_stack.py
@@ -101,6 +101,7 @@ class ApplicationStack(Stack):
             self, 
             "SparkProcessingRuntime", 
             name="TaxiAggregation",
+            release_label=dsf.processing.EmrRuntimeVersion.V6_15,
             runtime_configuration=[
                 {
                     "classification": "spark-defaults",


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

The spark data lake example needs to configure the EMR version accordingly to the dockerfile used to package the dependencies in the venv otherwise venv injection doesn't work. By default EMR is using 7.3 but the Spark code is using EMR 6 for packaging the dependencies into the venv

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
