### PR TITLE
chore(tests): fix governance retention policy in e2e tests

### DIFF
--- a/framework/src/governance/lib/custom-authorizer-environment-helpers.ts
+++ b/framework/src/governance/lib/custom-authorizer-environment-helpers.ts
@@ -125,7 +125,7 @@ export function authorizerEnvironmentWorkflowSetup(
 
   const stateMachineLogGroup = new LogGroup(scope, 'StateMachineLogGroup', {
     logGroupName: `/aws/vendedlogs/states/${authorizerName}/environment`,
-    removalPolicy,
+    removalPolicy: removalPolicy || RemovalPolicy.RETAIN,
     retention: logRetention || DEFAULT_LOGS_RETENTION,
   });
 

--- a/framework/test/e2e/datazone-msk.e2e.test.ts
+++ b/framework/test/e2e/datazone-msk.e2e.test.ts
@@ -14,13 +14,13 @@ jest.setTimeout(10000000);
 
 // GIVEN
 const app = new cdk.App();
-const testStack = new TestStack('E2eTestStack', app);
+const testStack = new TestStack('DataZoneMskTestStack', app);
 const { stack } = testStack;
 
 stack.node.setContext('@data-solutions-framework-on-aws/removeDataOnDestroy', true);
 
 const cfnDomain = new CfnDomain(stack, 'CfnDomain', {
-  domainExecutionRole: 'arn:aws:iam::145388625860:role/service-role/AmazonDataZoneDomainExecution',
+  domainExecutionRole: `arn:aws:iam::${stack.account}:role/service-role/AmazonDataZoneDomainExecution`,
   name: 'dsfE2eTest',
 });
 
@@ -35,6 +35,7 @@ new DataZoneMskCentralAuthorizer(testStack.stack, 'MskAuthorizer', {
 
 new DataZoneMskEnvironmentAuthorizer(stack, 'MskEnvAuthorizer', {
   domainId: cfnDomain.attrId,
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
 });
 
 // mskCentralAuthorizer.registerAccount('123456789012', '123456789012');
@@ -51,6 +52,7 @@ new DataZoneGsrMskDataSource(stack, 'GsrMskDataSource', {
   clusterName: 'testCluster',
   runSchedule: Schedule.cron({ minute: '0', hour: '12' }),
   enableSchemaRegistryEvent: true,
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
 });
 
 // createSubscriptionTarget(stack, 'Consumer',


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Fix the e2e tests for the streaming governance by updating the removal policy

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
