### PR TITLE
fix: assignDbRolesToIAMRole causing Circular Structure Error

### DIFF
--- a/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
+++ b/framework/src/consumption/lib/redshift/redshift-serverless/redshift-serverless-workgroup.ts
@@ -354,7 +354,7 @@ export class RedshiftServerlessWorkgroup extends TrackedConstruct implements ICo
    * @param targetRole The IAM role to assign the Redshift DB roles to
    */
   public assignDbRolesToIAMRole(dbRoles: string[], targetRole: IRole) {
-    const idHash = Utils.generateHash(JSON.stringify(dbRoles) + ' ' + JSON.stringify(targetRole));
+    const idHash = Utils.generateHash(JSON.stringify(dbRoles) + ' ' + targetRole.node.id);
     this.accessData(`${idHash}AccessData`).assignDbRolesToIAMRole(dbRoles, targetRole);
   }
 


### PR DESCRIPTION
**Issue #975**

## Description of changes:

Circular structure error is coming from the idHash generation. Changed the `role` to use the id of the node instead.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
