### PR TITLE
feat: Add automatic Lambda runtime updates for custom resources

### DIFF
--- a/framework/src/utils/lib/dsf-provider.ts
+++ b/framework/src/utils/lib/dsf-provider.ts
@@ -249,7 +249,10 @@ export class DsfProvider extends Construct {
       logGroup: logGroup,
       role: role,
       bundling: props.bundling,
-      environment: props.environment,
+      environment: {
+        ...props.environment,
+        DSF_RUNTIME_VERSION: DsfProvider.CR_RUNTIME.toString(),
+      },
       timeout: props.timeout ?? DsfProvider.FUNCTION_TIMEOUT,
       vpc: this.vpc,
       vpcSubnets: this.subnets,

--- a/framework/test/unit/utils/dsf-provider.test.ts
+++ b/framework/test/unit/utils/dsf-provider.test.ts
@@ -6,6 +6,7 @@ import { App, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { SecurityGroup, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { ManagedPolicy, PolicyDocument, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
+
 import { DsfProvider } from '../../../src/utils/lib/dsf-provider';
 
 /**
@@ -146,6 +147,19 @@ describe('With default configuration, the construct ', () => {
         },
         Runtime: 'nodejs22.x',
         Timeout: 840,
+      }),
+    );
+  });
+
+  test('should set DSF_RUNTIME_VERSION environment variable', () => {
+    template.hasResourceProperties('AWS::Lambda::Function',
+      Match.objectLike({
+        Handler: 'on-event.handler',
+        Environment: {
+          Variables: Match.objectLike({
+            DSF_RUNTIME_VERSION: Match.anyValue(),
+          }),
+        },
       }),
     );
   });
@@ -463,6 +477,19 @@ describe('With isComplete handler configuration configuration, the construct ', 
         },
         Runtime: 'nodejs22.x',
         Timeout: 840,
+      }),
+    );
+  });
+
+  test('should set DSF_RUNTIME_VERSION environment variable for isComplete handler', () => {
+    template.hasResourceProperties('AWS::Lambda::Function',
+      Match.objectLike({
+        Handler: 'is-complete.handler',
+        Environment: {
+          Variables: Match.objectLike({
+            DSF_RUNTIME_VERSION: Match.anyValue(),
+          }),
+        },
       }),
     );
   });


### PR DESCRIPTION
- Add DSF_RUNTIME_VERSION environment variable to Lambda functions
- Ensures Lambda functions update when DSF framework runtime changes
- Add tests to verify environment variable is set correctly

**Issue #, if available:**
N/A

## Description of changes:

This change adds automatic Lambda runtime updates for custom resources by injecting a DSF_RUNTIME_VERSION environment variable that changes when the framework runtime is updated, ensuring existing deployed Lambda functions get updated automatically.

**Checklist**

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

This is not a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
